### PR TITLE
feat: fresh mini session (Alt+N) and live token counter

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Press `alt+b` (or run `/mini` from the command palette) during any OpenCode sess
 ### Trigger
 
 | Key | Action |
-|---|---|---|
+|---|---|
 | `alt+b` (configurable) | Toggle mini session (with main session context) |
 | `alt+n` (configurable) | Open a fresh mini session (no context) |
 | `/mini` | Open mini session (command palette) |
@@ -33,6 +33,7 @@ Press `alt+b` (or run `/mini` from the command palette) during any OpenCode sess
 |---|---|
 | `enter` | Send question / follow-up |
 | `alt+b` (configurable) | Hide overlay (resumable) |
+| `alt+n` (configurable) | Hide freshoverlay (resumable) |
 | `tab` | Change the model for the next question |
 | `esc` / `ctrl+c` | Cancel and close |
 
@@ -47,6 +48,7 @@ Add to your OpenCode TUI config (`~/.config/opencode/tui.json`):
       "model": "anthropic/claude-sonnet-4.6",
       "tokenLimit": 50000,
       "keybind": "alt+b",
+      "freshKeybind": "alt+n",
       "allowedTools": ["glob", "grep", "read", "list", "webfetch"]
     }]
   ]

--- a/README.md
+++ b/README.md
@@ -20,9 +20,11 @@ Press `alt+b` (or run `/mini` from the command palette) during any OpenCode sess
 ### Trigger
 
 | Key | Action |
-|---|---|
-| `alt+b` (configurable) | Toggle mini session overlay |
+|---|---|---|
+| `alt+b` (configurable) | Toggle mini session (with main session context) |
+| `alt+n` (configurable) | Open a fresh mini session (no context) |
 | `/mini` | Open mini session (command palette) |
+| `/mini-fresh` | Open fresh mini session (command palette) |
 | `/mini-model` | Change model for future mini sessions |
 
 ### Inside the mini session
@@ -61,9 +63,23 @@ All options are optional. Defaults are shown below.
 | Option | Type | Default | Description |
 |---|---|---|---|
 | `model` | `string \| null` | `null` | Override model as `providerID/modelID` (e.g. `"anthropic/claude-sonnet-4-5"`). `null` auto-detects from current session. |
-| `tokenLimit` | `number` | `50000` | Maximum tokens of session context to include. |
-| `keybind` | `string \| false` | `"alt+b"` | Global keybind. Set to `false` or `"none"` to disable. |
+| `tokenLimit` | `number` | `50000` | Maximum tokens of session context to include (for `alt+b`). |
+| `keybind` | `string \| false` | `"alt+b"` | Global keybind for normal mini session. Set to `false` or `"none"` to disable. |
+| `freshKeybind` | `string \| false` | `"alt+n"` | Global keybind for fresh mini session (no context). Set to `false` or `"none"` to disable. |
 | `allowedTools` | `string[] \| null` | `null` | Tools the mini session agent can use. See [Tool access](#tool-access). |
+
+## Token counter
+
+The mini session header shows a live token counter (`used / limit`). The `used` value is the sum of real API-reported input tokens across all mini session turns, so you always know how much of your context window is consumed.
+
+### Normal vs fresh
+
+| Mode | Context included | When to use |
+|---|---|---|
+| **`alt+b`** (normal) | Main session history packed into system prompt (up to `tokenLimit`) | You need the AI to know what happened in your current session |
+| **`alt+n`** (fresh) | No main session context — just tool definitions and instructions | Quick questions that don't need session history; uses fewer tokens |
+
+The `tokenLimit` config only affects `alt+b` — it caps how much main session history gets injected.
 
 ## Tool access
 

--- a/src/components/AnswerDialog.tsx
+++ b/src/components/AnswerDialog.tsx
@@ -8,6 +8,7 @@ import type { TuiPluginApi } from "@opencode-ai/plugin/tui";
 import type { Part } from "@opencode-ai/sdk/v2";
 import { createMemo, Show } from "solid-js";
 import { THINKING_TEXT } from "../constants";
+import { sumMiniSessionTokens } from "../context";
 import type {
   AnswerDialogProps,
   AnswerDialogState,
@@ -102,6 +103,10 @@ export function AnswerDialog(props: AnswerDialogProps) {
       ),
   );
 
+  const totalTokens = createMemo(() =>
+    sumMiniSessionTokens(props.state.entries),
+  );
+
   return (
     <box
       position="absolute"
@@ -137,9 +142,14 @@ export function AnswerDialog(props: AnswerDialogProps) {
           alignItems="center"
           marginBottom={1}
         >
-          <text fg={theme.text}>
-            <b>{props.title}</b>
-          </text>
+          <box flexDirection="row" gap={2} alignItems="center">
+            <text fg={theme.text}>
+              <b>{props.title}</b>
+            </text>
+            <text fg={theme.textMuted}>
+              {totalTokens().toLocaleString()} / {props.tokenLimit.toLocaleString()} tokens
+            </text>
+          </box>
           <HintBar api={props.api} hideKey={props.hideKey} />
         </box>
         {/* transcript */}
@@ -464,6 +474,7 @@ export function createOverlaySlot(getOverlay: () => OverlayState | undefined) {
             title={current().title}
             modelName={current().modelName}
             hideKey={current().hideKey}
+            tokenLimit={current().tokenLimit}
             state={current().state}
             onScroller={current().onScroller}
             onInput={current().onInput}

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,4 +1,4 @@
-import { DEFAULT_ALLOWED_TOOLS, DEFAULT_FULL_TOKEN_LIMIT, DEFAULT_KEYBIND } from "./constants";
+import { DEFAULT_ALLOWED_TOOLS, DEFAULT_FRESH_KEYBIND, DEFAULT_FULL_TOKEN_LIMIT, DEFAULT_KEYBIND } from "./constants";
 import type { MiniConfig } from "./types";
 
 export function parseConfig(options: unknown): MiniConfig {
@@ -16,6 +16,7 @@ export function parseConfig(options: unknown): MiniConfig {
       DEFAULT_FULL_TOKEN_LIMIT,
     ),
     keybind: parseKeybind(input.keybind),
+    freshKeybind: parseKeybind(input.freshKeybind, DEFAULT_FRESH_KEYBIND),
     allowedTools: parseAllowedTools(input.allowedTools),
   };
 }
@@ -26,9 +27,9 @@ function parsePositiveNumber(value: unknown, fallback: number) {
     : fallback;
 }
 
-function parseKeybind(value: unknown): string | false {
+function parseKeybind(value: unknown, fallback = DEFAULT_KEYBIND): string | false {
   if (value === false || value === "none") return false;
-  return typeof value === "string" && value.trim() ? value.trim() : DEFAULT_KEYBIND;
+  return typeof value === "string" && value.trim() ? value.trim() : fallback;
 }
 
 function parseAllowedTools(value: unknown): string[] | null {

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,6 +1,7 @@
 export const PLUGIN_ID = "local.opencode-mini-session";
 
 export const CMD_OPEN = "mini.open";
+export const CMD_OPEN_FRESH = "mini.open-fresh";
 export const CMD_HIDE = "mini.hide";
 export const CMD_CLOSE = "mini.close";
 export const CMD_CONTINUE = "mini.continue";
@@ -17,6 +18,7 @@ export const SCROLL_PAGE_DELTA = 14;
 
 export const DEFAULT_FULL_TOKEN_LIMIT = 50_000;
 export const DEFAULT_KEYBIND = "alt+b";
+export const DEFAULT_FRESH_KEYBIND = "alt+n";
 export const THINKING_TEXT = "Thinking...";
 
 export const SAFE_TOOLS = {

--- a/src/context.ts
+++ b/src/context.ts
@@ -29,8 +29,8 @@ export function formatFullContext(entries: SessionEntry[], tokenLimit: number) {
     if (usedTokens >= tokenLimit) break;
   }
 
-  if (selected.length === 0) return "No conversation context available.";
-  return selected.reverse().join("\n\n");
+  if (selected.length === 0) return { context: "No conversation context available.", usedTokens: 0 };
+  return { context: selected.reverse().join("\n\n"), usedTokens };
 }
 
 function formatEntry(entry: SessionEntry) {
@@ -70,4 +70,14 @@ function truncate(value: string, maxLength: number) {
 
 export function estimateTokens(text: string) {
   return Math.ceil(text.length / 3.4);
+}
+
+export function sumMiniSessionTokens(entries: SessionEntry[]): number {
+  let sum = 0;
+  for (const entry of entries) {
+    if (entry.info.role === "assistant" && entry.info.tokens?.input) {
+      sum += entry.info.tokens.input;
+    }
+  }
+  return sum;
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,12 +8,14 @@ import {
   CMD_CONTINUE,
   CMD_HIDE,
   CMD_OPEN,
+  CMD_OPEN_FRESH,
   CMD_PAGE_DOWN,
   CMD_PAGE_UP,
   CMD_SCROLL_BOTTOM,
   CMD_SCROLL_DOWN,
   CMD_SCROLL_TOP,
   CMD_SCROLL_UP,
+  DEFAULT_FRESH_KEYBIND,
   DEFAULT_KEYBIND,
   PLUGIN_ID,
   SCROLL_LINE_DELTA,
@@ -29,6 +31,7 @@ import type {
 const tui: TuiPlugin = async (api, options) => {
   const config = parseConfig(options);
   const keybind = config.keybind || DEFAULT_KEYBIND;
+  const freshKeybind = config.freshKeybind || DEFAULT_FRESH_KEYBIND;
   const [overlay, setOverlay] = createSignal<OverlayState | undefined>(
     undefined,
     { equals: false },
@@ -139,6 +142,34 @@ const tui: TuiPlugin = async (api, options) => {
       },
       {
         namespace: "palette",
+        name: CMD_OPEN_FRESH,
+        title: "mini fresh",
+        desc: "Open a fresh mini session without main session context",
+        category: "Plugin",
+        slashName: "mini-fresh",
+        enabled: () => api.route.current.name === "session",
+        run() {
+          const currentRoute = api.route.current;
+          if (currentRoute.name !== "session") return;
+          const { sessionID } = currentRoute.params as { sessionID: string };
+          if (!activeDialog) setOriginSessionID(sessionID);
+          void openMiniSession(api, config, setOverlay, {
+            get: () => activeDialog,
+            set: (dialog) => {
+              activeDialog = dialog;
+              if (!dialog) setOriginSessionID(undefined);
+            },
+          }, {
+            get: selectedModel,
+            set: setSelectedModel,
+          }, (onAfterSelect) => openModelPicker(api, config, sessionID, { get: selectedModel, set: setSelectedModel }, () => {
+            modelPickerOpen = false;
+            onAfterSelect();
+          }), true);
+        },
+      },
+      {
+        namespace: "palette",
         name: CMD_CHANGE_MODEL,
         title: "mini model",
         desc: "Change the model for future mini-session questions",
@@ -156,7 +187,10 @@ const tui: TuiPlugin = async (api, options) => {
         },
       },
     ],
-    bindings: [{ key: keybind, cmd: CMD_OPEN, desc: "Open a mini session" }],
+    bindings: [
+      { key: keybind, cmd: CMD_OPEN, desc: "Open a mini session" },
+      { key: freshKeybind, cmd: CMD_OPEN_FRESH, desc: "Open a fresh mini session" },
+    ],
   });
 };
 

--- a/src/session.ts
+++ b/src/session.ts
@@ -25,6 +25,17 @@ type ModelSelectValue =
       variant?: string;
     };
 
+function getMainSessionInputTokens(api: TuiPluginApi, sessionID: string): number {
+  const messages = api.state.session.messages(sessionID);
+  for (let i = messages.length - 1; i >= 0; i--) {
+    const msg = messages[i];
+    if (msg.role === "assistant" && msg.tokens?.input) {
+      return msg.tokens.input;
+    }
+  }
+  return 0;
+}
+
 const MINI_AGENT = "general";
 const ADDITIONAL_PERMISSION_IDS = [
   "edit",
@@ -49,6 +60,7 @@ export async function openMiniSession(
   active: ActiveDialog,
   modelPreference: ModelPreferenceState,
   openPickerFn: (onAfterSelect: () => void) => void,
+  fresh = false,
 ) {
   const currentRoute = api.route.current;
 
@@ -62,12 +74,16 @@ export async function openMiniSession(
 
   const activeDialog = active.get();
   if (activeDialog) {
-    activeDialog.show();
-    return;
+    if (fresh) {
+      void activeDialog.close();
+    } else {
+      activeDialog.show();
+      return;
+    }
   }
 
   const { sessionID } = currentRoute.params as { sessionID: string };
-  const title = "mini session";
+  const title = fresh ? "mini session (fresh)" : "mini session";
   void startQuestion(
     api,
     config,
@@ -77,6 +93,7 @@ export async function openMiniSession(
     active,
     modelPreference,
     openPickerFn,
+    fresh,
   );
 }
 
@@ -89,9 +106,11 @@ export async function startQuestion(
   active: ActiveDialog,
   modelPreference: ModelPreferenceState,
   openPickerFn: (onAfterSelect: () => void) => void,
+  fresh = false,
 ) {
-  const entries = getSessionEntries(api, sessionID);
-  const context = formatFullContext(entries, config.tokenLimit);
+  const entries = fresh ? [] : getSessionEntries(api, sessionID);
+  const context = fresh ? "" : formatFullContext(entries, config.tokenLimit).context;
+  const contextTokens = fresh ? 0 : Math.min(getMainSessionInputTokens(api, sessionID), config.tokenLimit);
   const toolIDs = await getAvailableToolIDs(api);
   const resolvedTools = resolveAllowedTools(config.allowedTools, toolIDs);
   const system = buildSystemPrompt(context, resolvedTools);
@@ -109,6 +128,7 @@ export async function startQuestion(
     loading: false,
     scrollbarVisible: false,
     messageModels: {},
+    contextTokens,
   };
 
   const submissionModelQueue: string[] = [];
@@ -263,6 +283,7 @@ export async function startQuestion(
       title,
       modelName: getModelName(),
       hideKey,
+      tokenLimit: config.tokenLimit,
       state: dialogState,
       onScroller: (scroller) => {
         overlayScroller = scroller;
@@ -577,14 +598,16 @@ export function extractAssistantText(
 
 function buildSystemPrompt(context: string, allowedTools: string[]) {
   const intro =
-    "You are answering a quick side question about an ongoing coding session. Below is the conversation context from the session. Answer concisely based on what you can see.";
+    "You are answering a quick side question about an ongoing coding session. Answer concisely.";
 
   const toolNote =
     allowedTools.length === 0
       ? " No tools are available in this session. Do not attempt to use any tools."
       : ` You may only use the following tools: ${allowedTools.join(", ")}. Do not attempt to use any other tools.`;
 
-  return `${intro}${toolNote}\n\n<session-context>\n${context}\n</session-context>`;
+  if (!context) return `${intro}${toolNote}`;
+
+  return `${intro} Below is the conversation context from the session.${toolNote}\n\n<session-context>\n${context}\n</session-context>`;
 }
 
 function resolveAllowedTools(

--- a/src/types.ts
+++ b/src/types.ts
@@ -6,6 +6,7 @@ export type MiniConfig = {
   model: string | null;
   tokenLimit: number;
   keybind: string | false;
+  freshKeybind: string | false;
   allowedTools: string[] | null;
 };
 
@@ -48,6 +49,7 @@ export type AnswerDialogState = {
   scrollbarVisible: boolean;
   error?: string;
   messageModels: Record<string, string>;
+  contextTokens: number;
 };
 
 export type AnswerDialogProps = {
@@ -55,6 +57,7 @@ export type AnswerDialogProps = {
   title: string;
   modelName: string;
   hideKey: string;
+  tokenLimit: number;
   state: AnswerDialogState;
   onScroller?: (scroller: ScrollBoxRenderable | undefined) => void;
   onInput?: (input: InputRenderable | undefined) => void;


### PR DESCRIPTION
## Changes

### Fresh mini session (Alt+N)
- New FreshKeybind config option (default Alt+N)
- Alt+N opens a context-free mini session (no main session history)
- Closes any existing mini session before starting fresh
- Palette command /mini-fresh also available

### Live token counter
- Header shows used  limit token counter using real API-reported tokens.input
- Sums across all turns for cumulative mini session spent
- Extracted into pure sumMiniSessionTokens() function

### Documentation
- README updated with fresh mode, token counter section, and config options

### Files
8 files changed, +120 / -20