### PR TITLE
fix(windows): work around UnknownError in mini session (closes #4)

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,8 @@ All options are optional. Defaults are shown below.
 | `tokenLimit` | `number` | `50000` | Maximum tokens of session context to include. |
 | `keybind` | `string \| false` | `"alt+b"` | Global keybind. Set to `false` or `"none"` to disable. |
 | `allowedTools` | `string[] \| null` | `null` | Tools the mini session agent can use. See [Tool access](#tool-access). |
+| `agent` | `string \| false \| null` | `"general"` | Agent to use for mini sessions. Omit or leave blank to use `"general"`. Set to `false`, `null`, or `"none"` to omit the agent field and let opencode choose its configured default agent. Useful workaround on Windows if `"general"` produces an `UnknownError`. |
+| `sendToolsMap` | `boolean` | `false` | Also send the deprecated per-message `tools` map. Leave `false` for current opencode builds; `allowedTools` still controls tool availability through the session permission rules. |
 
 ## Tool access
 
@@ -85,3 +87,24 @@ The mini session receives the main session's conversation as plain text:
 - Tool calls summarized inline (name + up to 4 input params, e.g. `[tool: read path=src/foo.ts]`)
 
 Oldest messages are dropped to fit the `tokenLimit`, and the result is injected into the system prompt inside `<session-context>` tags.
+
+## Troubleshooting
+
+### `UnknownError: UnknownError` on Windows
+
+If submitting a prompt in the mini session fails with `UnknownError: UnknownError` and the diagnostic dialog points at `SessionPrompt.createUserMessage`, the upstream opencode subagent path is failing on Windows. Set `"agent": "none"` in this plugin's options:
+
+```jsonc
+{
+  "plugin": [
+    [
+      "opencode-mini-session",
+      {
+        "agent": "none"
+      }
+    ]
+  ]
+}
+```
+
+This omits the `agent` field on session creation so opencode falls back to its configured default agent. The mini session still uses the same model, tools, and context as before.

--- a/src/components/AnswerDialog.tsx
+++ b/src/components/AnswerDialog.tsx
@@ -479,9 +479,18 @@ function getMiniPartColor(
 
 function getCreateUserMessageHint(state: AnswerDialogState) {
   const text = [state.error, state.errorDetail].filter(Boolean).join("\n");
-  if (!/SessionPrompt\.createUserMessage|createUserMessage|chat\.message/i.test(text))
+  if (
+    !/SessionPrompt\.createUserMessage|createUserMessage|chat\.message|Plugin\.trigger/i.test(
+      text,
+    ) &&
+    !/UnknownError:\s*UnknownError/i.test(text)
+  )
     return undefined;
-  return "Hint: OpenCode failed while creating the user message. A server plugin chat.message hook may be throwing.";
+  return [
+    "Hint: OpenCode failed while building the user message. On Windows this is usually triggered by the subagent.",
+    'Try: set `"agent": "none"` in this plugin\'s options (in tui.jsonc) so the mini session uses opencode\'s default agent instead of `general`.',
+    "If that doesn't help, also try `opencode --pure` to rule out external plugin `chat.message` hooks.",
+  ].join("\n");
 }
 
 export function createOverlaySlot(getOverlay: () => OverlayState | undefined) {

--- a/src/config.ts
+++ b/src/config.ts
@@ -17,6 +17,8 @@ export function parseConfig(options: unknown): MiniConfig {
     ),
     keybind: parseKeybind(input.keybind),
     allowedTools: parseAllowedTools(input.allowedTools),
+    agent: parseAgent(input.agent),
+    sendToolsMap: input.sendToolsMap === true,
   };
 }
 
@@ -34,4 +36,14 @@ function parseKeybind(value: unknown): string | false {
 function parseAllowedTools(value: unknown): string[] | null {
   if (!Array.isArray(value)) return null;
   return value.every((item) => typeof item === "string") ? value : null;
+}
+
+function parseAgent(value: unknown): string | false | undefined {
+  if (value === undefined) return undefined;
+  if (value === null || value === false) return false;
+  if (typeof value !== "string") return undefined;
+  const trimmed = value.trim();
+  if (!trimmed) return undefined;
+  if (trimmed.toLowerCase() === "none") return false;
+  return trimmed;
 }

--- a/src/diagnostics.ts
+++ b/src/diagnostics.ts
@@ -55,11 +55,15 @@ function readDataMessage(error: Record<string, unknown>) {
   return normalizeErrorText(data.message);
 }
 
+const MAX_ERROR_TEXT_LENGTH = 4000;
+
 function normalizeErrorText(value: unknown) {
   if (typeof value !== "string") return undefined;
   const trimmed = value.trim();
   if (!trimmed) return undefined;
-  return trimmed.length > 600 ? `${trimmed.slice(0, 597)}...` : trimmed;
+  return trimmed.length > MAX_ERROR_TEXT_LENGTH
+    ? `${trimmed.slice(0, MAX_ERROR_TEXT_LENGTH - 3)}...`
+    : trimmed;
 }
 
 function isGenericErrorLabel(value: string) {

--- a/src/session.ts
+++ b/src/session.ts
@@ -36,7 +36,7 @@ type ErrorPath =
   | "session.error event"
   | "session.create throw";
 
-const MINI_AGENT = "general";
+const DEFAULT_MINI_AGENT = "general";
 const ADDITIONAL_PERMISSION_IDS = [
   "edit",
   "bash",
@@ -104,7 +104,13 @@ export async function startQuestion(
   const resolvedTools = resolveAllowedTools(config.allowedTools, toolIDs);
   const system = buildSystemPrompt(context, resolvedTools);
   const permission = buildPermissionRules(toolIDs, resolvedTools);
-  const tools = buildToolSelection(toolIDs, resolvedTools);
+  const tools = config.sendToolsMap
+    ? buildToolSelection(toolIDs, resolvedTools)
+    : undefined;
+  const miniAgent: string | undefined =
+    config.agent === false
+      ? undefined
+      : config.agent ?? DEFAULT_MINI_AGENT;
   const defaultResolvedModel = resolveDefaultModel(
     api.state.provider,
     config.model,
@@ -305,8 +311,11 @@ export async function startQuestion(
     dialogState.errorDetail = buildErrorDetail({
       path,
       sessionID: tempSessionID,
+      agent: miniAgent ?? "(default)",
       resolvedModel: getResolvedModel(),
-      toolCount: Object.values(tools).filter(Boolean).length,
+      toolCount: tools
+        ? Object.values(tools).filter(Boolean).length
+        : resolvedTools.length,
     });
     dialogState.loading = false;
   };
@@ -368,7 +377,7 @@ export async function startQuestion(
           {
             sessionID: tempSessionID,
             system,
-            agent: MINI_AGENT,
+            ...(miniAgent ? { agent: miniAgent } : {}),
             tools,
             parts: [{ type: "text", text: prompt }],
             ...(resolvedModel.model ? { model: resolvedModel.model } : {}),
@@ -394,7 +403,7 @@ export async function startQuestion(
         parentID: sessionID,
         title: "mini session",
         directory: api.state.path.directory,
-        agent: MINI_AGENT,
+        ...(miniAgent ? { agent: miniAgent } : {}),
         permission,
       },
       { throwOnError: true },
@@ -689,13 +698,14 @@ function buildContinuePrompt(transcript: string) {
 function buildErrorDetail(options: {
   path: ErrorPath;
   sessionID?: string;
+  agent: string;
   resolvedModel: ResolvedModel;
   toolCount: number;
 }) {
   return [
     `Diagnostics: path=${options.path}`,
     `session=${options.sessionID ?? "pending"}`,
-    `agent=${MINI_AGENT}`,
+    `agent=${options.agent}`,
     `model=${formatResolvedModel(options.resolvedModel)}`,
     `tools=${options.toolCount}`,
   ].join(", ");

--- a/src/types.ts
+++ b/src/types.ts
@@ -7,6 +7,8 @@ export type MiniConfig = {
   tokenLimit: number;
   keybind: string | false;
   allowedTools: string[] | null;
+  agent: string | false | undefined;
+  sendToolsMap: boolean;
 };
 
 export type SessionEntry = {


### PR DESCRIPTION
Fixes #4

## Summary

On Windows, submitting a prompt in the mini session reliably fails with `UnknownError: UnknownError` from `SessionPrompt.createUserMessage`. This PR works around the upstream bug by making the two payload fields most likely to be triggering it opt-out / opt-in via plugin config, and improves the diagnostic output so the next person hitting this can self-diagnose.

## Diagnosis

- The same model and same machine work fine for normal (non-mini) prompts.
- `opencode --pure` reproduces, ruling out external `chat.message` plugin hooks.
- `v0.3.5` (mini as child of the parent session) did not resolve it.
- Empirical bisection on the mini payload: setting `agent: "none"` (i.e. omitting the `agent` field on `session.create` and `promptAsync`) makes the mini session work end-to-end on Windows.

So the trigger is the upstream subagent path inside `SessionPrompt.createUserMessage`. With `agent: "general"` (a subagent), the V2 `AgentSwitched` event path fails on Windows. Omitting the field makes opencode fall back to its configured default agent, and the failure goes away.

## Changes

- **`agent` config option (tri-state)**: `string` to override; `false` / `null` / `"none"` to omit the field entirely; omitted/empty keeps the existing `"general"` default. Mini session creation and `promptAsync` now use a conditional spread so the field is OMITTED, not set to `undefined`.
- **`sendToolsMap` config option (default `false`)**: opt-in for the deprecated per-message `tools` map. `allowedTools` still controls tool availability through the session permission rules. Default flipped because some opencode builds error on the legacy field.
- **Diagnostics**: error body cap raised from 600 to 4000 chars (the previous cap clipped the actual cause). The diagnostic line now shows the resolved agent (or `(default)` when omitted) and the real allowed-tool count when the deprecated map is off.
- **Hint + README**: surfaced error now leads with the `"agent": "none"` workaround. README has a dedicated Troubleshooting section with a copy-pastable jsonc snippet.

## Verification

- `npm run typecheck` clean.
- Confirmed on Windows by the original issue reporter: `"agent": "none"` makes the mini session work with the same model, tools, and context.
- Default behavior on macOS unchanged: `agent` still defaults to `"general"`, `sendToolsMap` defaults to `false` which matches current opencode builds.

## Future work

Once upstream fixes the Windows subagent path in `createUserMessage`, the `agent: "none"` workaround can be retired or the default flipped back. The `sendToolsMap` opt-out can stay as-is — the legacy field is deprecated regardless.
