### PR TITLE
feat: add automatical plugin updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,3 +106,25 @@ The mini session receives the main session's conversation as plain text:
 - Tool calls summarized inline (name + up to 4 input params, e.g. `[tool: read path=src/foo.ts]`)
 
 Oldest messages are dropped to fit the `tokenLimit`, and the result is injected into the system prompt inside `<session-context>` tags.
+
+## Troubleshooting
+
+### Force update from older versions
+
+Older versions may stay cached by OpenCode. To force a fresh install, close OpenCode, remove the cached npm plugin package, then start OpenCode again.
+
+Linux and macOS:
+
+```sh
+rm -rf ~/.cache/opencode/node_modules/opencode-mini-session
+opencode
+```
+
+Windows PowerShell:
+
+```powershell
+Remove-Item -Recurse -Force "$HOME\.cache\opencode\node_modules\opencode-mini-session"
+opencode
+```
+
+For more information, see the official OpenCode docs for [npm plugins and plugin cache](https://opencode.ai/docs/plugins/#how-plugins-are-installed) and [configuration locations](https://opencode.ai/docs/config/#locations).

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "solid-js": "^1.9.12"
       },
       "devDependencies": {
+        "@types/node": "^25.9.1",
         "typescript": "^5.9.3",
         "vitest": "^4.1.7"
       }
@@ -1123,6 +1124,16 @@
       "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "25.9.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.1.tgz",
+      "integrity": "sha512-xfrlY7UD5rMJk3ZVJP8BNzS28J36YJg+xp+LPXV1TdWxr8uMH5A860QNxYDGQe/ylDSgjxE52Q9VnO7p75tJxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": ">=7.24.0 <7.24.7"
+      }
     },
     "node_modules/@vitest/expect": {
       "version": "4.1.7",
@@ -2697,6 +2708,13 @@
       "engines": {
         "node": ">=14.17"
       }
+    },
+    "node_modules/undici-types": {
+      "version": "7.24.6",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.24.6.tgz",
+      "integrity": "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/update-browserslist-db": {
       "version": "1.2.3",

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "solid-js": "^1.9.12"
   },
   "devDependencies": {
+    "@types/node": "^25.9.1",
     "typescript": "^5.9.3",
     "vitest": "^4.1.7"
   }

--- a/src/components/AnswerDialog.tsx
+++ b/src/components/AnswerDialog.tsx
@@ -167,6 +167,9 @@ export function AnswerDialog(props: AnswerDialogProps) {
               {props.state.notice ? (
                 <text fg={theme.warning}>Warning: {props.state.notice}</text>
               ) : null}
+              {props.state.update ? (
+                <text fg={theme.warning}>{props.state.update}</text>
+              ) : null}
               {messages().length > 0 ? (
                 messages().map((message) => (
                   <box flexDirection="column" gap={0}>

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
 import type { TuiPlugin, TuiPluginModule } from "@opencode-ai/plugin/tui";
-import { createEffect, createSignal } from "solid-js";
+import { createEffect, createSignal, untrack } from "solid-js";
 import { createOverlaySlot } from "./components/AnswerDialog";
 import { parseConfig } from "./config";
 import {
@@ -25,8 +25,9 @@ import type {
   ModelPreference,
   OverlayState,
 } from "./types";
+import { startAutoUpdate } from "./update";
 
-const tui: TuiPlugin = async (api, options) => {
+const tui: TuiPlugin = async (api, options, meta) => {
   const config = parseConfig(options);
   const keybind = config.keybind || DEFAULT_KEYBIND;
   const [overlay, setOverlay] = createSignal<OverlayState | undefined>(
@@ -38,10 +39,19 @@ const tui: TuiPlugin = async (api, options) => {
     { equals: false },
   );
   const [originSessionID, setOriginSessionID] = createSignal<string | undefined>(undefined);
+  const [updateWarning, setUpdateWarning] = createSignal<string | undefined>(undefined);
   let activeDialog: ActiveDialogController | undefined;
   let modelPickerOpen = false;
 
   api.lifecycle.onDispose(() => activeDialog?.close());
+  startAutoUpdate(api, meta, setUpdateWarning);
+
+  createEffect(() => {
+    const warning = updateWarning();
+    const current = untrack(overlay);
+    if (!current || current.state.update === warning) return;
+    setOverlay({ ...current, state: { ...current.state, update: warning } });
+  });
 
   createEffect(() => {
     const origin = originSessionID();
@@ -134,7 +144,7 @@ const tui: TuiPlugin = async (api, options) => {
           }, (onAfterSelect) => openModelPicker(api, config, sessionID, { get: selectedModel, set: setSelectedModel }, () => {
               modelPickerOpen = false;
               onAfterSelect();
-            }));
+            }), updateWarning);
         },
       },
       {

--- a/src/session.ts
+++ b/src/session.ts
@@ -51,6 +51,7 @@ export async function openMiniSession(
   active: ActiveDialog,
   modelPreference: ModelPreferenceState,
   openPickerFn: (onAfterSelect: () => void) => void,
+  getUpdateWarning?: () => string | undefined,
 ) {
   const currentRoute = api.route.current;
 
@@ -77,6 +78,7 @@ export async function openMiniSession(
     active,
     modelPreference,
     openPickerFn,
+    getUpdateWarning,
   );
 }
 
@@ -88,6 +90,7 @@ export async function startQuestion(
   active: ActiveDialog,
   modelPreference: ModelPreferenceState,
   openPickerFn: (onAfterSelect: () => void) => void,
+  getUpdateWarning?: () => string | undefined,
 ) {
   const entries = getSessionEntries(api, sessionID);
   const context = formatFullContext(entries, config.tokenLimit);
@@ -109,6 +112,7 @@ export async function startQuestion(
     streamingAnswer: "",
     loading: false,
     scrollbarVisible: false,
+    update: getUpdateWarning?.(),
     notice: formatMiniNotice(
       defaultResolvedModel.notice,
       ...resolvedAgent.notices,

--- a/src/types.ts
+++ b/src/types.ts
@@ -49,6 +49,7 @@ export type AnswerDialogState = {
   loading: boolean;
   scrollbarVisible: boolean;
   notice?: string;
+  update?: string;
   error?: string;
   errorDetail?: string;
   messageModels: Record<string, string>;

--- a/src/update.ts
+++ b/src/update.ts
@@ -56,7 +56,8 @@ export function handleAutoUpdateResult(
     setUpdateWarning(warning);
     api.ui.toast({
       variant: "info",
-      message: `${result.name} updated to ${result.latest}. Restart opencode to finish.`,
+      message: `New ${result.name} ${result.latest} version available. Restart opencode to apply the update.`,
+      duration: 8000
     });
     return;
   }
@@ -65,6 +66,7 @@ export function handleAutoUpdateResult(
     api.ui.toast({
       variant: "warning",
       message: `Could not update ${result.name}. Clear the opencode plugin cache and restart.`,
+      duration: 8000
     });
   }
 }

--- a/src/update.ts
+++ b/src/update.ts
@@ -1,0 +1,197 @@
+import { readFile, rm } from "node:fs/promises";
+import { basename, dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import type { TuiPluginApi, TuiPluginMeta } from "@opencode-ai/plugin/tui";
+import type { Setter } from "solid-js";
+
+const PACKAGE_NAME = "opencode-mini-session";
+
+type PackageJson = {
+  name?: string;
+  version?: string;
+  dependencies?: Record<string, string>;
+};
+
+export type UpdateResult =
+  | { updated: true; name: string; current: string; latest: string; removeDir: string }
+  | {
+      updated: false;
+      error: "remove_failed";
+      name: string;
+      current: string;
+      latest: string;
+      removeDir: string;
+    }
+  | { updated: false };
+
+export async function checkAutoUpdate(
+  meta: TuiPluginMeta,
+  signal: AbortSignal,
+): Promise<UpdateResult> {
+  if (meta.source !== "npm") return { updated: false };
+
+  const packageDir = await findPackageDir(dirname(fileURLToPath(import.meta.url)));
+  if (!packageDir) return { updated: false };
+
+  return checkPackageUpdate(packageDir, signal);
+}
+
+export function startAutoUpdate(
+  api: TuiPluginApi,
+  meta: TuiPluginMeta,
+  setUpdateWarning: Setter<string | undefined>,
+) {
+  void checkAutoUpdate(meta, api.lifecycle.signal)
+    .then((result) => handleAutoUpdateResult(api, result, setUpdateWarning))
+    .catch(() => {});
+}
+
+export function handleAutoUpdateResult(
+  api: { ui: Pick<TuiPluginApi["ui"], "toast"> },
+  result: UpdateResult,
+  setUpdateWarning: (warning: string | undefined) => void,
+) {
+  if (result.updated) {
+    const warning = buildUpdateWarning(result.latest);
+    setUpdateWarning(warning);
+    api.ui.toast({
+      variant: "info",
+      message: `${result.name} updated to ${result.latest}. Restart opencode to finish.`,
+    });
+    return;
+  }
+
+  if ("error" in result && result.error === "remove_failed") {
+    api.ui.toast({
+      variant: "warning",
+      message: `Could not update ${result.name}. Clear the opencode plugin cache and restart.`,
+    });
+  }
+}
+
+export function buildUpdateWarning(latest: string) {
+  return `New version available: ${latest}. Restart opencode to finish updating.`;
+}
+
+export async function checkPackageUpdate(
+  packageDir: string,
+  signal: AbortSignal,
+  fetchVersion: (name: string, signal: AbortSignal) => Promise<string | undefined> = fetchLatestVersion,
+  remove: (path: string) => Promise<void> = (path) =>
+    rm(path, { recursive: true, force: true }),
+): Promise<UpdateResult> {
+  const pkg = await readPackageJson(join(packageDir, "package.json"));
+  if (!pkg?.name || !pkg.version) return { updated: false };
+
+  const latest = await fetchVersion(pkg.name, signal);
+  if (!latest || !isVersionNewer(latest, pkg.version)) return { updated: false };
+
+  const removeDir = await selectUpdateRemoveDir(packageDir, pkg.name);
+  try {
+    await remove(removeDir);
+  } catch {
+    return {
+      updated: false,
+      error: "remove_failed",
+      name: pkg.name,
+      current: pkg.version,
+      latest,
+      removeDir,
+    };
+  }
+
+  return {
+    updated: true,
+    name: pkg.name,
+    current: pkg.version,
+    latest,
+    removeDir,
+  };
+}
+
+export function parseLatestVersion(data: unknown) {
+  return data && typeof data === "object" && typeof (data as { version?: unknown }).version === "string"
+    ? (data as { version: string }).version
+    : undefined;
+}
+
+export async function selectUpdateRemoveDir(packageDir: string, name: string) {
+  const nodeModulesDir = dirname(packageDir);
+  if (basename(nodeModulesDir) !== "node_modules") return packageDir;
+
+  const wrapperDir = dirname(nodeModulesDir);
+  const wrapperPkg = await readPackageJson(join(wrapperDir, "package.json"));
+  return wrapperPkg?.dependencies?.[name] ? wrapperDir : packageDir;
+}
+
+export function isVersionNewer(latest: string, current: string) {
+  const next = parseVersion(latest);
+  const prev = parseVersion(current);
+  if (!next || !prev) return false;
+
+  for (let i = 0; i < 3; i++) {
+    if (next.parts[i] !== prev.parts[i]) return next.parts[i] > prev.parts[i];
+  }
+
+  if (!next.pre.length && prev.pre.length) return true;
+  if (next.pre.length && !prev.pre.length) return false;
+
+  for (let i = 0; i < Math.max(next.pre.length, prev.pre.length); i++) {
+    const a = next.pre[i];
+    const b = prev.pre[i];
+    if (a === undefined) return false;
+    if (b === undefined) return true;
+    if (a === b) continue;
+
+    const aNumber = /^\d+$/.test(a) ? Number(a) : undefined;
+    const bNumber = /^\d+$/.test(b) ? Number(b) : undefined;
+    if (aNumber !== undefined && bNumber !== undefined) return aNumber > bNumber;
+    if (aNumber !== undefined) return false;
+    if (bNumber !== undefined) return true;
+    return a > b;
+  }
+
+  return false;
+}
+
+async function findPackageDir(startDir: string) {
+  let dir = startDir;
+  for (;;) {
+    const pkg = await readPackageJson(join(dir, "package.json"));
+    if (pkg?.name === PACKAGE_NAME) return dir;
+
+    const parent = dirname(dir);
+    if (parent === dir) return undefined;
+    dir = parent;
+  }
+}
+
+async function readPackageJson(path: string): Promise<PackageJson | undefined> {
+  try {
+    const data = JSON.parse(await readFile(path, "utf8"));
+    return data && typeof data === "object" ? (data as PackageJson) : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+async function fetchLatestVersion(name: string, signal: AbortSignal) {
+  try {
+    const response = await fetch(`https://registry.npmjs.org/${encodeURIComponent(name)}/latest`, {
+      signal,
+    });
+    if (!response.ok) return undefined;
+    return parseLatestVersion(await response.json());
+  } catch {
+    return undefined;
+  }
+}
+
+function parseVersion(version: string) {
+  const match = version.match(/^v?(\d+)\.(\d+)\.(\d+)(?:-([0-9A-Za-z.-]+))?(?:\+.+)?$/);
+  if (!match) return undefined;
+  return {
+    parts: [Number(match[1]), Number(match[2]), Number(match[3])],
+    pre: match[4]?.split(".") ?? [],
+  };
+}

--- a/tests/update.test.ts
+++ b/tests/update.test.ts
@@ -1,0 +1,218 @@
+import { mkdir, readFile, rm, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { describe, expect, it, vi } from "vitest";
+import {
+  buildUpdateWarning,
+  checkPackageUpdate,
+  handleAutoUpdateResult,
+  isVersionNewer,
+  parseLatestVersion,
+  selectUpdateRemoveDir,
+} from "../src/update";
+
+async function tempDir() {
+  const dir = join(tmpdir(), `opencode-mini-session-test-${crypto.randomUUID()}`);
+  await mkdir(dir, { recursive: true });
+  return dir;
+}
+
+async function writeJson(path: string, data: unknown) {
+  await writeFile(path, JSON.stringify(data), "utf8");
+}
+
+async function packageDir(root: string, version = "0.3.0") {
+  await mkdir(root, { recursive: true });
+  await writeJson(join(root, "package.json"), {
+    name: "opencode-mini-session",
+    version,
+  });
+  return root;
+}
+
+describe("isVersionNewer", () => {
+  it("compares major, minor, and patch versions", () => {
+    expect(isVersionNewer("1.0.1", "1.0.0")).toBe(true);
+    expect(isVersionNewer("1.1.0", "1.0.9")).toBe(true);
+    expect(isVersionNewer("2.0.0", "1.9.9")).toBe(true);
+    expect(isVersionNewer("1.0.0", "1.0.0")).toBe(false);
+    expect(isVersionNewer("1.0.0", "1.0.1")).toBe(false);
+  });
+
+  it("handles v prefixes, prereleases, and build metadata", () => {
+    expect(isVersionNewer("v1.0.1", "1.0.0")).toBe(true);
+    expect(isVersionNewer("1.0.0", "1.0.0-beta.1")).toBe(true);
+    expect(isVersionNewer("1.0.0-beta.2", "1.0.0-beta.1")).toBe(true);
+    expect(isVersionNewer("1.0.0-beta.1", "1.0.0")).toBe(false);
+    expect(isVersionNewer("1.0.0+build.2", "1.0.0+build.1")).toBe(false);
+  });
+});
+
+describe("parseLatestVersion", () => {
+  it("accepts npm latest payloads", () => {
+    expect(parseLatestVersion({ version: "0.4.0" })).toBe("0.4.0");
+  });
+
+  it("rejects invalid payloads", () => {
+    expect(parseLatestVersion({ version: 4 })).toBeUndefined();
+    expect(parseLatestVersion(null)).toBeUndefined();
+    expect(parseLatestVersion("0.4.0")).toBeUndefined();
+  });
+});
+
+describe("selectUpdateRemoveDir", () => {
+  it("selects the wrapper directory for opencode cache layouts", async () => {
+    const root = await tempDir();
+    try {
+      const wrapper = join(root, "wrapper");
+      const installed = join(wrapper, "node_modules", "opencode-mini-session");
+      await mkdir(installed, { recursive: true });
+      await writeJson(join(wrapper, "package.json"), {
+        dependencies: { "opencode-mini-session": "0.3.0" },
+      });
+
+      await expect(selectUpdateRemoveDir(installed, "opencode-mini-session")).resolves.toBe(wrapper);
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("falls back to the package directory when no wrapper is detected", async () => {
+    const root = await tempDir();
+    try {
+      const installed = join(root, "node_modules", "opencode-mini-session");
+      await mkdir(installed, { recursive: true });
+
+      await expect(selectUpdateRemoveDir(installed, "opencode-mini-session")).resolves.toBe(installed);
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("checkPackageUpdate", () => {
+  it("returns no update when latest is equal or older", async () => {
+    const root = await tempDir();
+    try {
+      const installed = await packageDir(root, "0.4.0");
+      const signal = new AbortController().signal;
+
+      await expect(checkPackageUpdate(installed, signal, async () => "0.4.0")).resolves.toEqual({
+        updated: false,
+      });
+      await expect(checkPackageUpdate(installed, signal, async () => "0.3.9")).resolves.toEqual({
+        updated: false,
+      });
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("removes the selected directory when an update is needed", async () => {
+    const root = await tempDir();
+    try {
+      const wrapper = join(root, "wrapper");
+      const installed = await packageDir(join(wrapper, "node_modules", "opencode-mini-session"));
+      await writeJson(join(wrapper, "package.json"), {
+        dependencies: { "opencode-mini-session": "0.3.0" },
+      });
+
+      const result = await checkPackageUpdate(installed, new AbortController().signal, async () => "0.4.0");
+
+      expect(result).toEqual({
+        updated: true,
+        name: "opencode-mini-session",
+        current: "0.3.0",
+        latest: "0.4.0",
+        removeDir: wrapper,
+      });
+      await expect(readFile(join(wrapper, "package.json"), "utf8")).rejects.toThrow();
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("returns metadata when removal fails", async () => {
+    const root = await tempDir();
+    try {
+      const installed = await packageDir(root, "0.3.0");
+
+      const result = await checkPackageUpdate(
+        installed,
+        new AbortController().signal,
+        async () => "0.4.0",
+        async () => {
+          throw new Error("failed");
+        },
+      );
+
+      expect(result).toEqual({
+        updated: false,
+        error: "remove_failed",
+        name: "opencode-mini-session",
+        current: "0.3.0",
+        latest: "0.4.0",
+        removeDir: root,
+      });
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("update presentation", () => {
+  it("builds the restart warning", () => {
+    expect(buildUpdateWarning("0.4.0")).toBe(
+      "New version available: 0.4.0. Restart opencode to finish updating.",
+    );
+  });
+
+  it("sets warning and shows toast for successful updates", () => {
+    const toast = vi.fn();
+    const setUpdateWarning = vi.fn();
+
+    handleAutoUpdateResult(
+      { ui: { toast } },
+      {
+        updated: true,
+        name: "opencode-mini-session",
+        current: "0.3.0",
+        latest: "0.4.0",
+        removeDir: "/cache/wrapper",
+      },
+      setUpdateWarning,
+    );
+
+    expect(setUpdateWarning).toHaveBeenCalledWith(
+      "New version available: 0.4.0. Restart opencode to finish updating.",
+    );
+    expect(toast).toHaveBeenCalledWith({
+      variant: "info",
+      message: "opencode-mini-session updated to 0.4.0. Restart opencode to finish.",
+    });
+  });
+
+  it("shows a warning toast for removal failures", () => {
+    const toast = vi.fn();
+    const setUpdateWarning = vi.fn();
+
+    handleAutoUpdateResult(
+      { ui: { toast } },
+      {
+        updated: false,
+        error: "remove_failed",
+        name: "opencode-mini-session",
+        current: "0.3.0",
+        latest: "0.4.0",
+        removeDir: "/cache/wrapper",
+      },
+      setUpdateWarning,
+    );
+
+    expect(setUpdateWarning).not.toHaveBeenCalled();
+    expect(toast).toHaveBeenCalledWith({
+      variant: "warning",
+      message: "Could not update opencode-mini-session. Clear the opencode plugin cache and restart.",
+    });
+  });
+});


### PR DESCRIPTION
Closes #9

## Summary
- automatically detects newer npm versions of `opencode-mini-session` on startup
- removes the stale cached plugin wrapper or package so OpenCode reinstalls the new version after restart
- shows a longer-lived toast and a mini session dialog warning telling users a new version is available and restart is required
- adds troubleshooting steps in `README.md` for forcing updates on older cached installs
- adds update coverage in `tests/update.test.ts` and Node type definitions for the new filesystem-based updater code

## Why
Older npm-installed plugin copies could stay cached and not pick up new releases automatically. This change prepares the cache for a clean reinstall on the next OpenCode launch, makes the restart requirement clear in the UI, and documents manual recovery steps for users already stuck on older cached versions.