### PR TITLE
feat: add collapsible thinking blocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ Press `alt+b` (or run `/mini` from the command palette) during any OpenCode sess
 | `enter` | Send question / follow-up |
 | `shift+enter` | Inject mini transcript into the main thread |
 | `alt+b` (configurable) | Hide overlay (resumable) |
+| `ctrl+t` (configurable) | Toggle thinking blocks |
 | `tab` | Change the model for the next question |
 | `esc` / `ctrl+c` | Cancel and close |
 
@@ -59,6 +60,8 @@ All options are optional. Defaults are shown below.
 | `agent` | `string \| null` | `null` | `null` or omitted uses plugin-managed mini mode. A string uses an existing OpenCode agent by name. |
 | `tokenLimit` | `number` | `50000` | Maximum tokens of session context to include. |
 | `keybind` | `string \| false` | `"alt+b"` | Global keybind. Set to `false` or `"none"` to disable. |
+| `enableThinking` | `boolean` | `false` | Show thinking blocks collapsed by default. |
+| `toggleThinkingKeybind` | `string \| false` | `"ctrl+t"` | Thinking toggle keybind inside the mini session. Set to `false` or `"none"` to disable. |
 | ~`allowedTools`~ | `string[] \| null` | `null` | Deprecated. Use custom OpenCode agents for custom permissions. |
 
 If you want to customize the plugin, your config should look something like this:
@@ -70,6 +73,8 @@ If you want to customize the plugin, your config should look something like this
       "model": "anthropic/claude-sonnet-4.6",
       "tokenLimit": 10000,
       "keybind": "alt+m",
+      "enableThinking": false,
+      "toggleThinkingKeybind": "ctrl+t",
       "agent": "build",
       ...
     }]

--- a/src/components/AnswerDialog.tsx
+++ b/src/components/AnswerDialog.tsx
@@ -123,6 +123,14 @@ export function AnswerDialog(props: AnswerDialogProps) {
   const createUserMessageHint = createMemo(() =>
     getCreateUserMessageHint(props.state),
   );
+  const footerModelName = createMemo(() =>
+    formatFooterModelName(props.modelName, {
+      width: transcriptWidth,
+      canContinue: canContinue(),
+      hideKey: props.hideKey,
+      toggleThinkingKeybind: props.toggleThinkingKeybind,
+    }),
+  );
 
   return (
     <box
@@ -304,12 +312,13 @@ export function AnswerDialog(props: AnswerDialogProps) {
               if (input) input.value = "";
             }}
           />
-          <box
-            flexDirection="row"
-            justifyContent="space-between"
-            alignItems="center"
-            width={transcriptWidth}
-          >
+            <box
+              flexDirection="row"
+              justifyContent="space-between"
+              alignItems="center"
+              width={transcriptWidth}
+              gap={3}
+            >
             <box flexDirection="row" gap={2}>
               <Show when={canContinue()}>
                 <ActionButton
@@ -338,7 +347,7 @@ export function AnswerDialog(props: AnswerDialogProps) {
                 onPress={props.onChangeModel}
               />
             </box>
-            <text fg={theme.textMuted}>{props.modelName}</text>
+            <text fg={theme.textMuted}>{footerModelName()}</text>
           </box>
         </box>
       </box>
@@ -609,6 +618,49 @@ function summarizeToolInput(
 
 function formatMiniPart(part: MiniPart) {
   return part.text;
+}
+
+function formatFooterModelName(
+  modelName: string,
+  options: {
+    width: number;
+    canContinue: boolean;
+    hideKey: string | false;
+    toggleThinkingKeybind: string | false;
+  },
+) {
+  const actionWidth = getFooterActionsWidth(options);
+  const maxWidth = Math.max(0, options.width - actionWidth - 4);
+  return truncateWithEllipsis(modelName, maxWidth);
+}
+
+function getFooterActionsWidth(options: {
+  canContinue: boolean;
+  hideKey: string | false;
+  toggleThinkingKeybind: string | false;
+}) {
+  const actions = [
+    options.canContinue
+      ? getActionButtonWidth("Continue", "shift+enter")
+      : 0,
+    getActionButtonWidth("Toggle", options.hideKey),
+    getActionButtonWidth("Thinking", options.toggleThinkingKeybind),
+    getActionButtonWidth("Model", "tab"),
+  ].filter((width) => width > 0);
+
+  if (actions.length === 0) return 0;
+  return actions.reduce((total, width) => total + width, 0) + (actions.length - 1) * 2;
+}
+
+function getActionButtonWidth(label: string, keybind?: string | false) {
+  return label.length + (keybind ? keybind.length + 1 : 0);
+}
+
+function truncateWithEllipsis(text: string, maxWidth: number) {
+  if (maxWidth <= 0) return "";
+  if (text.length <= maxWidth) return text;
+  if (maxWidth <= 3) return ".".repeat(maxWidth);
+  return `${text.slice(0, maxWidth - 3)}...`;
 }
 
 function getReasoningPartID(part: Extract<Part, { type: "reasoning" }>) {

--- a/src/components/AnswerDialog.tsx
+++ b/src/components/AnswerDialog.tsx
@@ -356,8 +356,10 @@ export function AnswerDialog(props: AnswerDialogProps) {
 }
 
 function buildMiniMessages(state: AnswerDialogState): MiniMessage[] {
-  const messages = state.entries
-    .map((entry) => ({
+  const messages: MiniMessage[] = [];
+
+  for (const entry of state.entries) {
+    const message: MiniMessage = {
       id: entry.info.id,
       role: entry.info.role,
       parts: entry.parts
@@ -367,8 +369,19 @@ function buildMiniMessages(state: AnswerDialogState): MiniMessage[] {
         entry.info.role === "assistant"
           ? state.messageModels[entry.info.id]
           : undefined,
-    }))
-    .filter((message) => message.parts.length > 0);
+    };
+
+    if (message.parts.length === 0) continue;
+
+    const previous = messages[messages.length - 1];
+    if (shouldMergeMiniMessages(previous, message)) {
+      previous.parts.push(...message.parts);
+      previous.modelName ??= message.modelName;
+      continue;
+    }
+
+    messages.push(message);
+  }
 
   if (!state.streamingAnswer) return messages;
 
@@ -423,6 +436,15 @@ function buildMiniMessages(state: AnswerDialogState): MiniMessage[] {
   }
 
   return messages;
+}
+
+function shouldMergeMiniMessages(
+  previous: MiniMessage | undefined,
+  current: MiniMessage,
+) {
+  return Boolean(
+    previous && previous.role === "assistant" && current.role === "assistant",
+  );
 }
 
 type ThinkingMiniPart = Extract<MiniPart, { type: "reasoning" }>;
@@ -515,7 +537,12 @@ function getMiniPartTopMargin(
   if (index === 0) return parts[0]?.type === "reasoning" && role === "assistant" ? 1 : 0;
   const previous = parts[index - 1];
   const current = parts[index];
-  if (current.type === "reasoning" && previous.type === "reasoning") return 1;
+  if (current.type === "reasoning") {
+    return previous.type === "tool" || previous.type === "reasoning" ? 1 : 0;
+  }
+  if (current.type === "tool") {
+    return previous.type === "tool" || previous.type === "reasoning" ? 1 : 0;
+  }
   return current.type === "text" && previous.type !== "text" ? 1 : 0;
 }
 

--- a/src/components/AnswerDialog.tsx
+++ b/src/components/AnswerDialog.tsx
@@ -206,7 +206,13 @@ export function AnswerDialog(props: AnswerDialogProps) {
                       </b>
                     </text>
                     {message.parts.map((part, index) => (
-                      <box marginTop={getMiniPartTopMargin(message.parts, index)}>
+                      <box
+                        marginTop={getMiniPartTopMargin(
+                          message.parts,
+                          index,
+                          message.role,
+                        )}
+                      >
                         {part.type === "reasoning" ? (
                           <ThinkingPart
                             api={props.api}
@@ -452,7 +458,7 @@ function estimateMiniMessagesHeight(
     lines += 1;
     for (let index = 0; index < message.parts.length; index++) {
       const part = message.parts[index];
-      lines += getMiniPartTopMargin(message.parts, index);
+      lines += getMiniPartTopMargin(message.parts, index, message.role);
       if (part.type === "reasoning") {
         lines += estimateWrappedLines(
           formatThinkingHeader(part, isThinkingPartExpanded(state, part), state),
@@ -492,8 +498,12 @@ function estimateWrappedLines(text: string, width: number) {
     );
 }
 
-function getMiniPartTopMargin(parts: MiniPart[], index: number) {
-  if (index === 0) return 0;
+function getMiniPartTopMargin(
+  parts: MiniPart[],
+  index: number,
+  role: MiniMessage["role"],
+) {
+  if (index === 0) return parts[0]?.type === "reasoning" && role === "assistant" ? 1 : 0;
   const previous = parts[index - 1];
   const current = parts[index];
   if (current.type === "reasoning" && previous.type === "reasoning") return 1;
@@ -540,15 +550,47 @@ function toReasoningMiniParts(part: Extract<Part, { type: "reasoning" }>) {
   const baseID = getReasoningPartID(part);
   const time = "time" in part && isReasoningTime(part.time) ? part.time : undefined;
   const metadata = "metadata" in part ? part.metadata : undefined;
-  return [
-    {
+  const segments = splitReasoningText(part.text.trim());
+
+  return segments.map((text, index) => ({
     type: "reasoning" as const,
-    id: baseID,
-    text: part.text.trim(),
-    time,
+    id: segments.length === 1 ? baseID : `${baseID}:${index}`,
+    text,
+    time: index === 0 ? time : undefined,
     metadata,
-    },
-  ];
+  }));
+}
+
+function splitReasoningText(text: string) {
+  const titlePattern = /\*\*([^*\n]+)\*\*/g;
+  const matches = [...text.matchAll(titlePattern)].filter((match) =>
+    isReasoningTitleMatch(text, match.index ?? -1),
+  );
+
+  if (matches.length <= 1) return [text];
+
+  const segments: string[] = [];
+  if ((matches[0].index ?? 0) > 0) {
+    const intro = text.slice(0, matches[0].index).trim();
+    if (intro) segments.push(intro);
+  }
+
+  for (let index = 0; index < matches.length; index++) {
+    const start = matches[index].index ?? 0;
+    const end = matches[index + 1]?.index ?? text.length;
+    const segment = text.slice(start, end).trim();
+    if (segment) segments.push(segment);
+  }
+
+  return segments.length > 0 ? segments : [text];
+}
+
+function isReasoningTitleMatch(text: string, index: number) {
+  if (index < 0) return false;
+  if (index === 0) return true;
+  const before = text.slice(0, index).trimEnd();
+  if (!before) return true;
+  return /[.!?)]$/.test(before) || before.endsWith("...");
 }
 
 function summarizeToolInput(

--- a/src/components/AnswerDialog.tsx
+++ b/src/components/AnswerDialog.tsx
@@ -48,7 +48,13 @@ function buildSyntaxStyle(
 
 type MiniPart =
   | { type: "text"; text: string }
-  | { type: "reasoning"; text: string }
+  | {
+      type: "reasoning";
+      id: string;
+      text: string;
+      time?: { start?: number; end?: number };
+      metadata?: unknown;
+    }
   | { type: "tool"; text: string; status: string }
   | { type: "meta"; text: string };
 
@@ -58,6 +64,19 @@ type MiniMessage = {
   parts: MiniPart[];
   modelName?: string;
 };
+
+const THINKING_SPINNER_FRAMES = [
+  "⠋",
+  "⠙",
+  "⠹",
+  "⠸",
+  "⠼",
+  "⠴",
+  "⠦",
+  "⠧",
+  "⠇",
+  "⠏",
+];
 
 export function AnswerDialog(props: AnswerDialogProps) {
   const theme = props.api.theme.current;
@@ -187,10 +206,19 @@ export function AnswerDialog(props: AnswerDialogProps) {
                       </b>
                     </text>
                     {message.parts.map((part, index) => (
-                      <box
-                        marginTop={getMiniPartTopMargin(message.parts, index)}
-                      >
-                        {message.role === "assistant" &&
+                      <box marginTop={getMiniPartTopMargin(message.parts, index)}>
+                        {part.type === "reasoning" ? (
+                          <ThinkingPart
+                            api={props.api}
+                            part={part}
+                            expanded={isThinkingPartExpanded(
+                              props.state,
+                              part,
+                            )}
+                            spinnerFrame={props.state.spinnerFrame}
+                            onToggle={() => props.onToggleThinkingPart(part.id)}
+                          />
+                        ) : message.role === "assistant" &&
                         part.type === "text" &&
                         !props.state.loading ? (
                           <markdown
@@ -288,8 +316,14 @@ export function AnswerDialog(props: AnswerDialogProps) {
               <ActionButton
                 api={props.api}
                 label="Toggle"
-                keybind={props.hideKey}
+                keybind={props.hideKey || undefined}
                 onPress={props.onHide}
+              />
+              <ActionButton
+                api={props.api}
+                label="Thinking"
+                keybind={props.toggleThinkingKeybind || undefined}
+                onPress={props.onToggleThinking}
               />
               <ActionButton
                 api={props.api}
@@ -312,7 +346,7 @@ function buildMiniMessages(state: AnswerDialogState): MiniMessage[] {
       id: entry.info.id,
       role: entry.info.role,
       parts: entry.parts
-        .map(toMiniPart)
+        .flatMap(toMiniParts)
         .filter((part): part is MiniPart => Boolean(part)),
       modelName:
         entry.info.role === "assistant"
@@ -376,6 +410,38 @@ function buildMiniMessages(state: AnswerDialogState): MiniMessage[] {
   return messages;
 }
 
+type ThinkingMiniPart = Extract<MiniPart, { type: "reasoning" }>;
+
+function ThinkingPart(props: {
+  api: TuiPluginApi;
+  part: ThinkingMiniPart;
+  expanded: boolean;
+  spinnerFrame: number;
+  onToggle: () => void;
+}) {
+  const theme = props.api.theme.current;
+  const header = () =>
+    formatThinkingHeader(props.part, props.expanded, props);
+  const body = () => getThinkingBodyText(props.part);
+
+  return (
+    <box flexDirection="column" gap={0} opacity={props.expanded ? 0.65 : 1}>
+      <box onMouseUp={props.onToggle}>
+        <text fg={theme.warning}>
+          <Show when={!props.expanded} fallback={header()}>
+            <b>{header()}</b>
+          </Show>
+        </text>
+      </box>
+      <Show when={props.expanded && body()}>
+        <box marginLeft={2} marginTop={1}>
+          <text fg={theme.markdownBlockQuote}>{body()}</text>
+        </box>
+      </Show>
+    </box>
+  );
+}
+
 function estimateMiniMessagesHeight(
   messages: MiniMessage[],
   state: AnswerDialogState,
@@ -384,8 +450,22 @@ function estimateMiniMessagesHeight(
   let lines = 0;
   for (const message of messages) {
     lines += 1;
-    for (const part of message.parts) {
-      lines += estimateWrappedLines(formatMiniPart(part), width);
+    for (let index = 0; index < message.parts.length; index++) {
+      const part = message.parts[index];
+      lines += getMiniPartTopMargin(message.parts, index);
+      if (part.type === "reasoning") {
+        lines += estimateWrappedLines(
+          formatThinkingHeader(part, isThinkingPartExpanded(state, part), state),
+          width,
+        );
+        if (isThinkingPartExpanded(state, part)) {
+          const body = getThinkingBodyText(part);
+          if (body)
+            lines += 1 + estimateWrappedLines(body, Math.max(1, width - 2));
+        }
+      } else {
+        lines += estimateWrappedLines(formatMiniPart(part), width);
+      }
     }
     lines += 1;
   }
@@ -416,14 +496,21 @@ function getMiniPartTopMargin(parts: MiniPart[], index: number) {
   if (index === 0) return 0;
   const previous = parts[index - 1];
   const current = parts[index];
+  if (current.type === "reasoning" && previous.type === "reasoning") return 1;
   return current.type === "text" && previous.type !== "text" ? 1 : 0;
+}
+
+function toMiniParts(part: Part): MiniPart[] {
+  if (part.type === "reasoning" && part.text.trim())
+    return toReasoningMiniParts(part);
+
+  const miniPart = toMiniPart(part);
+  return miniPart ? [miniPart] : [];
 }
 
 function toMiniPart(part: Part): MiniPart | undefined {
   if (part.type === "text" && part.text.trim())
     return { type: "text", text: part.text.trim() };
-  if (part.type === "reasoning" && part.text.trim())
-    return { type: "reasoning", text: part.text.trim() };
   if (part.type === "tool") {
     const toolName = part.tool.charAt(0).toUpperCase() + part.tool.slice(1);
     const inputSummary = summarizeToolInput(part.state.input);
@@ -449,6 +536,21 @@ function toMiniPart(part: Part): MiniPart | undefined {
   return undefined;
 }
 
+function toReasoningMiniParts(part: Extract<Part, { type: "reasoning" }>) {
+  const baseID = getReasoningPartID(part);
+  const time = "time" in part && isReasoningTime(part.time) ? part.time : undefined;
+  const metadata = "metadata" in part ? part.metadata : undefined;
+  return [
+    {
+    type: "reasoning" as const,
+    id: baseID,
+    text: part.text.trim(),
+    time,
+    metadata,
+    },
+  ];
+}
+
 function summarizeToolInput(
   input: { [key: string]: unknown } | undefined,
 ): string {
@@ -464,8 +566,96 @@ function summarizeToolInput(
 }
 
 function formatMiniPart(part: MiniPart) {
-  if (part.type === "reasoning") return `thinking: ${part.text}`;
   return part.text;
+}
+
+function getReasoningPartID(part: Extract<Part, { type: "reasoning" }>) {
+  return "id" in part && typeof part.id === "string" ? part.id : part.text;
+}
+
+function isReasoningTime(
+  value: unknown,
+): value is { start?: number; end?: number } {
+  return Boolean(value && typeof value === "object");
+}
+
+function isThinkingPartExpanded(
+  state: AnswerDialogState,
+  part: ThinkingMiniPart,
+) {
+  const toggled = Boolean(state.expandedThinkingPartIDs[part.id]);
+  return state.thinkingEnabled ? !toggled : toggled;
+}
+
+function formatThinkingHeader(
+  part: ThinkingMiniPart,
+  expanded: boolean,
+  spinnerSource: Pick<AnswerDialogState, "spinnerFrame">,
+) {
+  const title = getThinkingTitle(part);
+  const duration = formatThinkingDuration(part.time);
+  const prefix = isThinkingPartLoading(part)
+    ? `${THINKING_SPINNER_FRAMES[spinnerSource.spinnerFrame]} `
+    : expanded
+      ? "- "
+      : "+ ";
+  if (title) return `${prefix}Thought: ${title}${duration ? ` · ${duration}` : ""}`;
+  return `${prefix}Thought${duration ? `: ${duration}` : ""}`;
+}
+
+function isThinkingPartLoading(part: ThinkingMiniPart) {
+  if (!part.time) return false;
+  const start = Number(part.time.start);
+  const end = Number(part.time.end);
+  return Number.isFinite(start) && !Number.isFinite(end);
+}
+
+function getThinkingTitle(part: ThinkingMiniPart) {
+  return getExplicitThinkingTitle(part.text);
+}
+
+function getExplicitThinkingTitle(text: string) {
+  const line = text
+    .split("\n")
+    .find((candidate) => candidate.trim().length > 0)
+    ?.trim();
+  const match = line?.match(/^\*\*(.+?)\*\*/);
+  return match?.[1]?.trim() ? truncateThinkingTitle(match[1].trim()) : "";
+}
+
+function truncateThinkingTitle(title: string) {
+  return title.length > 80 ? `${title.slice(0, 77).trim()}...` : title;
+}
+
+function getThinkingBodyText(part: ThinkingMiniPart) {
+  const lines = part.text.split("\n");
+  const title = getThinkingTitle(part);
+  const titleIndex = lines.findIndex((line) => line.trim().length > 0);
+  if (titleIndex === -1) return "";
+
+  if (!title) return part.text;
+
+  lines[titleIndex] = lines[titleIndex].replace(/^\s*\*\*(.+?)\*\*/, "");
+
+  return lines
+    .slice(titleIndex)
+    .join("\n")
+    .replace(/^\s+/, "")
+    .trimEnd();
+}
+
+function formatThinkingDuration(time: ThinkingMiniPart["time"]) {
+  if (!time) return "";
+  const start = Number(time.start);
+  const end = Number(time.end);
+  if (!Number.isFinite(start) || !Number.isFinite(end) || end < start)
+    return "";
+  const diff = end - start;
+  const milliseconds =
+    start > 10_000_000_000 || end > 10_000_000_000 ? diff : diff * 1000;
+  if (milliseconds < 1000) return `${Math.round(milliseconds)}ms`;
+  const seconds = milliseconds / 1000;
+  return seconds < 10 ? `${seconds.toFixed(1)}s` : `${Math.round(seconds)}s`;
 }
 
 function getMiniPartColor(
@@ -498,6 +688,7 @@ export function createOverlaySlot(getOverlay: () => OverlayState | undefined) {
             version={current().version}
             modelName={current().modelName}
             hideKey={current().hideKey}
+            toggleThinkingKeybind={current().toggleThinkingKeybind}
             state={current().state}
             onScroller={current().onScroller}
             onInput={current().onInput}
@@ -505,6 +696,8 @@ export function createOverlaySlot(getOverlay: () => OverlayState | undefined) {
             onClose={current().onClose}
             onContinue={current().onContinue}
             onChangeModel={current().onChangeModel}
+            onToggleThinking={current().onToggleThinking}
+            onToggleThinkingPart={current().onToggleThinkingPart}
             onSubmit={current().onSubmit}
           />
         )}

--- a/src/components/HintBar.tsx
+++ b/src/components/HintBar.tsx
@@ -1,7 +1,7 @@
 /** @jsxImportSource @opentui/solid */
 import type { TuiPluginApi } from "@opencode-ai/plugin/tui";
 
-export function HintBar(props: { api: TuiPluginApi; hideKey: string }) {
+export function HintBar(props: { api: TuiPluginApi; hideKey: string | false }) {
   const theme = props.api.theme.current;
   return <text fg={theme.textMuted}>esc</text>;
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,4 +1,8 @@
-import { DEFAULT_FULL_TOKEN_LIMIT, DEFAULT_KEYBIND } from "./constants";
+import {
+  DEFAULT_FULL_TOKEN_LIMIT,
+  DEFAULT_KEYBIND,
+  DEFAULT_TOGGLE_THINKING_KEYBIND,
+} from "./constants";
 import type { MiniConfig } from "./types";
 
 export function parseConfig(options: unknown): MiniConfig {
@@ -16,7 +20,13 @@ export function parseConfig(options: unknown): MiniConfig {
       input.tokenLimit,
       DEFAULT_FULL_TOKEN_LIMIT,
     ),
-    keybind: parseKeybind(input.keybind),
+    keybind: parseKeybind(input.keybind, DEFAULT_KEYBIND),
+    enableThinking:
+      typeof input.enableThinking === "boolean" ? input.enableThinking : false,
+    toggleThinkingKeybind: parseKeybind(
+      input.toggleThinkingKeybind,
+      DEFAULT_TOGGLE_THINKING_KEYBIND,
+    ),
     allowedTools: parseAllowedTools(input.allowedTools),
     allowedToolsProvided: Object.hasOwn(input, "allowedTools"),
   };
@@ -28,9 +38,12 @@ function parsePositiveNumber(value: unknown, fallback: number) {
     : fallback;
 }
 
-function parseKeybind(value: unknown): string | false {
-  if (value === false || value === "none") return false;
-  return typeof value === "string" && value.trim() ? value.trim() : DEFAULT_KEYBIND;
+function parseKeybind(value: unknown, fallback: string): string | false {
+  if (value === false) return false;
+  if (typeof value !== "string") return fallback;
+  const keybind = value.trim();
+  if (!keybind) return fallback;
+  return keybind === "none" ? false : keybind;
 }
 
 function parseAgent(value: unknown): string | null {

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -5,6 +5,7 @@ export const CMD_HIDE = "mini.hide";
 export const CMD_CLOSE = "mini.close";
 export const CMD_CONTINUE = "mini.continue";
 export const CMD_CHANGE_MODEL = "mini.change-model";
+export const CMD_TOGGLE_THINKING = "mini.toggle-thinking";
 export const CMD_SCROLL_UP = "mini.scroll-up";
 export const CMD_SCROLL_DOWN = "mini.scroll-down";
 export const CMD_PAGE_UP = "mini.page-up";
@@ -17,6 +18,7 @@ export const SCROLL_PAGE_DELTA = 14;
 
 export const DEFAULT_FULL_TOKEN_LIMIT = 50_000;
 export const DEFAULT_KEYBIND = "alt+b";
+export const DEFAULT_TOGGLE_THINKING_KEYBIND = "ctrl+t";
 export const THINKING_TEXT = "Thinking...";
 
 export const SAFE_TOOLS = {

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,7 +14,7 @@ import {
   CMD_SCROLL_DOWN,
   CMD_SCROLL_TOP,
   CMD_SCROLL_UP,
-  DEFAULT_KEYBIND,
+  CMD_TOGGLE_THINKING,
   PLUGIN_ID,
   SCROLL_LINE_DELTA,
   SCROLL_PAGE_DELTA,
@@ -29,7 +29,7 @@ import { startAutoUpdate } from "./update";
 
 const tui: TuiPlugin = async (api, options, meta) => {
   const config = parseConfig(options);
-  const keybind = config.keybind || DEFAULT_KEYBIND;
+  const keybind = config.keybind;
   const [overlay, setOverlay] = createSignal<OverlayState | undefined>(
     undefined,
     { equals: false },
@@ -89,6 +89,7 @@ const tui: TuiPlugin = async (api, options, meta) => {
         },
       },
       { name: CMD_CONTINUE, run: () => overlay()?.onContinue() },
+      { name: CMD_TOGGLE_THINKING, run: () => overlay()?.onToggleThinking() },
       {
         name: CMD_CHANGE_MODEL,
         run: () => {
@@ -107,7 +108,10 @@ const tui: TuiPlugin = async (api, options, meta) => {
       },
     ],
     bindings: [
-      { key: keybind, cmd: CMD_HIDE },
+      ...(keybind ? [{ key: keybind, cmd: CMD_HIDE }] : []),
+      ...(config.toggleThinkingKeybind
+        ? [{ key: config.toggleThinkingKeybind, cmd: CMD_TOGGLE_THINKING }]
+        : []),
       { key: "shift+enter", cmd: CMD_CONTINUE },
       { key: "tab", cmd: CMD_CHANGE_MODEL },
       { key: "escape", cmd: CMD_CLOSE },
@@ -166,7 +170,9 @@ const tui: TuiPlugin = async (api, options, meta) => {
         },
       },
     ],
-    bindings: [{ key: keybind, cmd: CMD_OPEN, desc: "Open a mini session" }],
+    bindings: keybind
+      ? [{ key: keybind, cmd: CMD_OPEN, desc: "Open a mini session" }]
+      : [],
   });
 };
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -24,6 +24,7 @@ import type {
   ActiveDialogController,
   ModelPreference,
   OverlayState,
+  ThinkingPreferenceState,
 } from "./types";
 import { startAutoUpdate } from "./update";
 
@@ -38,10 +39,17 @@ const tui: TuiPlugin = async (api, options, meta) => {
     undefined,
     { equals: false },
   );
+  const [thinkingEnabled, setThinkingEnabled] = createSignal(
+    config.enableThinking,
+  );
   const [originSessionID, setOriginSessionID] = createSignal<string | undefined>(undefined);
   const [updateWarning, setUpdateWarning] = createSignal<string | undefined>(undefined);
   let activeDialog: ActiveDialogController | undefined;
   let modelPickerOpen = false;
+  const thinkingPreference: ThinkingPreferenceState = {
+    get: thinkingEnabled,
+    set: setThinkingEnabled,
+  };
 
   api.lifecycle.onDispose(() => activeDialog?.close());
   startAutoUpdate(api, meta, setUpdateWarning);
@@ -145,7 +153,7 @@ const tui: TuiPlugin = async (api, options, meta) => {
           }, {
             get: selectedModel,
             set: setSelectedModel,
-          }, (onAfterSelect) => openModelPicker(api, config, sessionID, { get: selectedModel, set: setSelectedModel }, () => {
+          }, thinkingPreference, (onAfterSelect) => openModelPicker(api, config, sessionID, { get: selectedModel, set: setSelectedModel }, () => {
               modelPickerOpen = false;
               onAfterSelect();
             }), updateWarning);

--- a/src/session.ts
+++ b/src/session.ts
@@ -491,12 +491,8 @@ export async function startQuestion(
     );
 
     unsubscribers.push(
-      api.event.on("message.part.delta", (event) => {
-        if (
-          event.properties.sessionID !== tempSessionID ||
-          event.properties.field !== "text"
-        )
-          return;
+      api.event.on("session.next.text.delta", (event) => {
+        if (event.properties.sessionID !== tempSessionID) return;
         dialogState.streamingAnswer += event.properties.delta;
         scheduleRenderOverlay();
       }),

--- a/src/session.ts
+++ b/src/session.ts
@@ -27,6 +27,7 @@ import type {
   ModelPreferenceState,
   OverlayState,
   ResolvedModel,
+  ThinkingPreferenceState,
 } from "./types";
 
 type ModelSelectValue =
@@ -49,6 +50,7 @@ export async function openMiniSession(
   setOverlay: Setter<OverlayState | undefined>,
   active: ActiveDialog,
   modelPreference: ModelPreferenceState,
+  thinkingPreference: ThinkingPreferenceState,
   openPickerFn: (onAfterSelect: () => void) => void,
   getUpdateWarning?: () => string | undefined,
 ) {
@@ -74,11 +76,12 @@ export async function openMiniSession(
     config,
     sessionID,
     setOverlay,
-    active,
-    modelPreference,
-    openPickerFn,
-    getUpdateWarning,
-  );
+      active,
+      modelPreference,
+      thinkingPreference,
+      openPickerFn,
+      getUpdateWarning,
+    );
 }
 
 export async function startQuestion(
@@ -88,6 +91,7 @@ export async function startQuestion(
   setOverlay: Setter<OverlayState | undefined>,
   active: ActiveDialog,
   modelPreference: ModelPreferenceState,
+  thinkingPreference: ThinkingPreferenceState,
   openPickerFn: (onAfterSelect: () => void) => void,
   getUpdateWarning?: () => string | undefined,
 ) {
@@ -112,7 +116,7 @@ export async function startQuestion(
     loading: false,
     scrollbarVisible: false,
     spinnerFrame: 0,
-    thinkingEnabled: config.enableThinking,
+    thinkingEnabled: thinkingPreference.get(),
     expandedThinkingPartIDs: {},
     update: getUpdateWarning?.(),
     notice: formatMiniNotice(
@@ -288,6 +292,7 @@ export async function startQuestion(
 
   const toggleThinking = () => {
     dialogState.thinkingEnabled = !dialogState.thinkingEnabled;
+    thinkingPreference.set(dialogState.thinkingEnabled);
     dialogState.expandedThinkingPartIDs = {};
     renderOverlay();
   };

--- a/src/session.ts
+++ b/src/session.ts
@@ -13,7 +13,6 @@ import {
   formatMiniNotice,
   resolveRuntimeMiniAgent,
 } from "./agent";
-import { DEFAULT_KEYBIND } from "./constants";
 import { getSessionEntries, formatFullContext } from "./context";
 import { getErrorMessage } from "./diagnostics";
 import {
@@ -104,7 +103,7 @@ export async function startQuestion(
   const getResolvedModel = () =>
     modelPreference.get() ?? defaultResolvedModel.model;
   const getModelName = () => formatResolvedModel(getResolvedModel());
-  const hideKey = config.keybind || DEFAULT_KEYBIND;
+  const hideKey = config.keybind;
   const previousFocus = api.renderer.currentFocusedRenderable;
 
   const dialogState: AnswerDialogState = {
@@ -112,6 +111,9 @@ export async function startQuestion(
     streamingAnswer: "",
     loading: false,
     scrollbarVisible: false,
+    spinnerFrame: 0,
+    thinkingEnabled: config.enableThinking,
+    expandedThinkingPartIDs: {},
     update: getUpdateWarning?.(),
     notice: formatMiniNotice(
       defaultResolvedModel.notice,
@@ -131,6 +133,7 @@ export async function startQuestion(
   let renderTimer: ReturnType<typeof setTimeout> | undefined;
   let scrollTimer: ReturnType<typeof setTimeout> | undefined;
   let focusTimer: ReturnType<typeof setTimeout> | undefined;
+  let spinnerTimer: ReturnType<typeof setInterval> | undefined;
   let overlayInput: InputRenderable | undefined;
   let overlayScroller: ScrollBoxRenderable | undefined;
 
@@ -144,6 +147,24 @@ export async function startQuestion(
     if (!focusTimer) return;
     clearTimeout(focusTimer);
     focusTimer = undefined;
+  };
+
+  const clearSpinnerTimer = () => {
+    if (!spinnerTimer) return;
+    clearInterval(spinnerTimer);
+    spinnerTimer = undefined;
+  };
+
+  const startSpinnerTimer = () => {
+    if (spinnerTimer || closed || hidden || !dialogState.loading) return;
+    spinnerTimer = setInterval(() => {
+      if (closed || hidden || !dialogState.loading) {
+        clearSpinnerTimer();
+        return;
+      }
+      dialogState.spinnerFrame = (dialogState.spinnerFrame + 1) % 10;
+      renderOverlay();
+    }, 80);
   };
 
   const scheduleInputFocus = () => {
@@ -186,11 +207,14 @@ export async function startQuestion(
     }
     clearScrollTimer();
     clearFocusTimer();
+    clearSpinnerTimer();
     setOverlay(undefined);
     restorePreviousFocus();
     api.ui.toast({
       variant: "info",
-      message: `mini hidden. Press ${hideKey} to show it.`,
+      message: hideKey
+        ? `mini hidden. Press ${hideKey} to show it.`
+        : "mini hidden. Run /mini to show it.",
       duration: 1000,
     });
   };
@@ -216,6 +240,7 @@ export async function startQuestion(
     if (renderTimer) clearTimeout(renderTimer);
     clearScrollTimer();
     clearFocusTimer();
+    clearSpinnerTimer();
     setOverlay(undefined);
     restorePreviousFocus();
     if (!tempSessionID) return;
@@ -261,6 +286,21 @@ export async function startQuestion(
     }
   };
 
+  const toggleThinking = () => {
+    dialogState.thinkingEnabled = !dialogState.thinkingEnabled;
+    dialogState.expandedThinkingPartIDs = {};
+    renderOverlay();
+  };
+
+  const toggleThinkingPart = (partID: string) => {
+    if (dialogState.expandedThinkingPartIDs[partID]) {
+      delete dialogState.expandedThinkingPartIDs[partID];
+    } else {
+      dialogState.expandedThinkingPartIDs[partID] = true;
+    }
+    renderOverlay();
+  };
+
   const renderOverlay = (options: { focusInput?: boolean } = {}) => {
     if (closed) return;
     if (renderTimer) {
@@ -274,6 +314,7 @@ export async function startQuestion(
       version,
       modelName: getModelName(),
       hideKey,
+      toggleThinkingKeybind: config.toggleThinkingKeybind,
       state: dialogState,
       onScroller: (scroller) => {
         overlayScroller = scroller;
@@ -286,11 +327,15 @@ export async function startQuestion(
       onContinue: () => void continueInMainThread(),
       onChangeModel: () =>
         openPickerFn(() => renderOverlay({ focusInput: true })),
+      onToggleThinking: toggleThinking,
+      onToggleThinkingPart: toggleThinkingPart,
       onSubmit: submitPrompt,
       scrollBy: (delta) => overlayScroller?.scrollBy(delta),
       scrollTo: (position) => overlayScroller?.scrollTo(position),
     });
     if (options.focusInput) scheduleInputFocus();
+    if (dialogState.loading) startSpinnerTimer();
+    else clearSpinnerTimer();
     if (dialogState.loading || dialogState.streamingAnswer)
       scheduleScrollToBottom();
   };
@@ -304,6 +349,7 @@ export async function startQuestion(
       resolvedAgent,
     });
     dialogState.loading = false;
+    clearSpinnerTimer();
   };
 
   const show = () => {
@@ -352,6 +398,7 @@ export async function startQuestion(
     dialogState.error = undefined;
     dialogState.errorDetail = undefined;
     dialogState.loading = true;
+    dialogState.spinnerFrame = 0;
     dialogState.streamingAnswer = "";
     submissionModelQueue.push(getModelName());
 
@@ -425,6 +472,7 @@ export async function startQuestion(
           dialogState.streamingAnswer = "No response generated.";
         }
         dialogState.loading = false;
+        clearSpinnerTimer();
         renderOverlay();
       }),
     );

--- a/src/types.ts
+++ b/src/types.ts
@@ -33,6 +33,11 @@ export type ModelPreferenceState = {
   set: (model: ModelPreference) => void;
 };
 
+export type ThinkingPreferenceState = {
+  get: () => boolean;
+  set: (enabled: boolean) => void;
+};
+
 export type ActiveDialog = {
   get: () => ActiveDialogController | undefined;
   set: (dialog: ActiveDialogController | undefined) => void;

--- a/src/types.ts
+++ b/src/types.ts
@@ -7,6 +7,8 @@ export type MiniConfig = {
   agent: string | null;
   tokenLimit: number;
   keybind: string | false;
+  enableThinking: boolean;
+  toggleThinkingKeybind: string | false;
   allowedTools: string[] | null;
   allowedToolsProvided: boolean;
 };
@@ -48,6 +50,9 @@ export type AnswerDialogState = {
   streamingAnswer: string;
   loading: boolean;
   scrollbarVisible: boolean;
+  spinnerFrame: number;
+  thinkingEnabled: boolean;
+  expandedThinkingPartIDs: Record<string, true>;
   notice?: string;
   update?: string;
   error?: string;
@@ -60,7 +65,8 @@ export type AnswerDialogProps = {
   title: string;
   version?: string;
   modelName: string;
-  hideKey: string;
+  hideKey: string | false;
+  toggleThinkingKeybind: string | false;
   state: AnswerDialogState;
   onScroller?: (scroller: ScrollBoxRenderable | undefined) => void;
   onInput?: (input: InputRenderable | undefined) => void;
@@ -68,6 +74,8 @@ export type AnswerDialogProps = {
   onClose: () => void;
   onContinue: () => void;
   onChangeModel: () => void;
+  onToggleThinking: () => void;
+  onToggleThinkingPart: (partID: string) => void;
   onSubmit: (value: string) => boolean;
 };
 

--- a/tests/agent.test.ts
+++ b/tests/agent.test.ts
@@ -16,6 +16,8 @@ function config(overrides: Partial<MiniConfig> = {}): MiniConfig {
     agent: null,
     tokenLimit: 50_000,
     keybind: "alt+b",
+    enableThinking: false,
+    toggleThinkingKeybind: "ctrl+t",
     allowedTools: null,
     allowedToolsProvided: false,
     ...overrides,
@@ -63,6 +65,32 @@ describe("config parsing", () => {
     expect(parseConfig({ allowedTools: ["read"] }).allowedToolsProvided).toBe(
       true,
     );
+  });
+
+  it("parses thinking config defaults and explicit values", () => {
+    expect(parseConfig({}).enableThinking).toBe(false);
+    expect(parseConfig({ enableThinking: false }).enableThinking).toBe(false);
+    expect(parseConfig({ enableThinking: true }).enableThinking).toBe(true);
+    expect(parseConfig({ enableThinking: "false" }).enableThinking).toBe(false);
+  });
+
+  it("parses thinking keybind values", () => {
+    expect(parseConfig({}).toggleThinkingKeybind).toBe("ctrl+t");
+    expect(
+      parseConfig({ toggleThinkingKeybind: " ctrl+r " })
+        .toggleThinkingKeybind,
+    ).toBe("ctrl+r");
+    expect(
+      parseConfig({ toggleThinkingKeybind: false }).toggleThinkingKeybind,
+    ).toBe(false);
+    expect(
+      parseConfig({ toggleThinkingKeybind: "none" }).toggleThinkingKeybind,
+    ).toBe(false);
+  });
+
+  it("disables the main keybind with false or none", () => {
+    expect(parseConfig({ keybind: false }).keybind).toBe(false);
+    expect(parseConfig({ keybind: "none" }).keybind).toBe(false);
   });
 });
 


### PR DESCRIPTION
## Summary
- add dedicated thinking blocks for assistant reasoning in the mini session instead of flattening reasoning into plain text
- add `enableThinking` and `toggleThinkingKeybind` config options, plus a `ctrl+t` toggle and footer action
- support per-block expand and collapse, a global thinking toggle, and persistence of the toggle state until OpenCode restarts
- render reasoning as raw text with durations, a loading spinner, better spacing between thoughts and tool calls, and merged assistant headers for multi-part responses
- truncate long footer model labels on narrow layouts and document the new behavior in the README
- add config parsing coverage for thinking defaults and disabled keybinds

## Why
- makes reasoning easier to scan without overwhelming the mini session by default
- keeps the overlay usable on narrow screens and during tool-heavy responses
- fixes repeated assistant headers and inconsistent spacing for models that emit untitled thoughts or split reasoning across multiple assistant entries

Closes #8