### PR TITLE
Add fresh mini session mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 # OpenCode mini session
 
-An OpenCode TUI plugin that opens an interactive mini temporary session for side questions, with full session context and multi-turn conversation.
+An OpenCode TUI plugin that opens interactive temporary mini sessions for side questions, either with copied main-session context or as a fresh no-context thread.
 
 https://github.com/user-attachments/assets/8201b065-2569-41ba-8eb7-ac2abddad2a5
 
 ## What it does
 
-Press `alt+b` (or run `/mini` from the command palette) during any OpenCode session. A popup overlay opens immediately with a text input at the bottom. Type a question and press Enter to send it. The plugin:
+Press `alt+b` for the default mini mode, or `alt+n` for a fresh mini mode with no copied conversation context. You can also run `/mini` or `/mini-fresh` from the command palette during any OpenCode session. A popup overlay opens immediately with a text input at the bottom. Type a question and press Enter to send it. The plugin:
 
 1. Gathers context from the current session (token-limited)
 2. Creates a temporary isolated session with that context
@@ -21,8 +21,10 @@ Press `alt+b` (or run `/mini` from the command palette) during any OpenCode sess
 
 | Key | Action |
 |---|---|
-| `alt+b` (configurable) | Toggle mini session overlay |
-| `/mini` | Open mini session (command palette) |
+| `alt+b` (configurable) | Toggle main mini session overlay |
+| `alt+n` (configurable) | Toggle fresh mini session overlay |
+| `/mini` | Open mini session with copied session context |
+| `/mini-fresh` | Open mini session with no copied session context |
 | `/mini-model` | Change model for future mini sessions |
 
 ### Inside the mini session
@@ -31,7 +33,7 @@ Press `alt+b` (or run `/mini` from the command palette) during any OpenCode sess
 |---|---|
 | `enter` | Send question / follow-up |
 | `shift+enter` | Inject mini transcript into the main thread |
-| `alt+b` (configurable) | Hide overlay (resumable) |
+| Active mode keybind, `alt+b` or `alt+n` | Hide overlay, resumable |
 | `ctrl+t` (configurable) | Toggle thinking blocks |
 | `tab` | Change the model for the next question |
 | `esc` / `ctrl+c` | Cancel and close |
@@ -60,7 +62,8 @@ All options are optional. Defaults are shown below.
 | `variant` | `string \| null` | `null` | Optional variant for the configured mini model, for example `"high"`. |
 | `agent` | `string \| null` | `null` | `null` or omitted uses plugin-managed mini mode. A string uses an existing OpenCode agent by name. |
 | `tokenLimit` | `number` | `50000` | Maximum tokens of session context to include. |
-| `keybind` | `string \| false` | `"alt+b"` | Global keybind. Set to `false` or `"none"` to disable. |
+| `keybind` | `string \| false` | `"alt+b"` | Main mini-session keybind. Set to `false` or `"none"` to disable. |
+| `freshKeybind` | `string \| false` | `"alt+n"` | Fresh mini-session keybind. Set to `false` or `"none"` to disable. |
 | `enableThinking` | `boolean` | `false` | Show thinking blocks collapsed by default. |
 | `toggleThinkingKeybind` | `string \| false` | `"ctrl+t"` | Thinking toggle keybind inside the mini session. Set to `false` or `"none"` to disable. |
 | ~`allowedTools`~ | `string[] \| null` | `null` | Deprecated. Use custom OpenCode agents for custom permissions. |
@@ -75,6 +78,7 @@ If you want to customize the plugin, your config should look something like this
       "variant": "high",
       "tokenLimit": 10000,
       "keybind": "alt+m",
+      "freshKeybind": "alt+f",
       "enableThinking": false,
       "toggleThinkingKeybind": "ctrl+t",
       "agent": "build",
@@ -104,6 +108,14 @@ For example, configure mini to use a custom `pirate` agent:
 
 ![Mini session using a custom pirate agent](.github/pirate.png)
 
+## Mini modes
+
+`mini` copies the current session conversation into the temporary session before you ask the first question.
+
+`mini fresh` still opens from the current OpenCode session and uses the same working directory, model controls, and continue-in-main-thread flow, but it does not copy any conversation context from the main session.
+
+Only one mini overlay can be active at a time. Opening one mode closes the other. Pressing the active mode's keybind toggles it hidden or visible again.
+
 ## Session context
 
 The mini session receives the main session's conversation as plain text:
@@ -113,6 +125,8 @@ The mini session receives the main session's conversation as plain text:
 - Tool calls summarized inline (name + up to 4 input params, e.g. `[tool: read path=src/foo.ts]`)
 
 Oldest messages are dropped to fit the `tokenLimit`, and the result is injected into the system prompt inside `<session-context>` tags.
+
+Fresh mini mode skips this copied-context step entirely.
 
 ## Troubleshooting
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # OpenCode mini session
 
-An OpenCode TUI plugin that opens interactive temporary mini sessions for side questions, either with copied main-session context or as a fresh no-context thread.
+An OpenCode TUI plugin that opens interactive temporary mini sessions for side questions, either with injected main-session context or as a fresh no-context thread.
 
 https://github.com/user-attachments/assets/8201b065-2569-41ba-8eb7-ac2abddad2a5
 
@@ -33,7 +33,7 @@ Press `alt+b` for the default mini mode, or `alt+n` for a fresh mini mode with n
 |---|---|
 | `enter` | Send question / follow-up |
 | `shift+enter` | Inject mini transcript into the main thread |
-| Active mode keybind, `alt+b` or `alt+n` | Hide overlay, resumable |
+| `alt+b` or `alt+n` (configurable) | Hide overlay, resumable |
 | `ctrl+t` (configurable) | Toggle thinking blocks |
 | `tab` | Change the model for the next question |
 | `esc` / `ctrl+c` | Cancel and close |
@@ -79,10 +79,9 @@ If you want to customize the plugin, your config should look something like this
       "tokenLimit": 10000,
       "keybind": "alt+m",
       "freshKeybind": "alt+f",
-      "enableThinking": false,
-      "toggleThinkingKeybind": "ctrl+t",
-      "agent": "build",
-      ...
+      "enableThinking": true,
+      "toggleThinkingKeybind": "alt+a",
+      "agent": "build"
     }]
   ]
 }
@@ -107,14 +106,6 @@ For example, configure mini to use a custom `pirate` agent:
 ```
 
 ![Mini session using a custom pirate agent](.github/pirate.png)
-
-## Mini modes
-
-`mini` copies the current session conversation into the temporary session before you ask the first question.
-
-`mini fresh` still opens from the current OpenCode session and uses the same working directory, model controls, and continue-in-main-thread flow, but it does not copy any conversation context from the main session.
-
-Only one mini overlay can be active at a time. Opening one mode closes the other. Pressing the active mode's keybind toggles it hidden or visible again.
 
 ## Session context
 

--- a/src/agent.ts
+++ b/src/agent.ts
@@ -2,10 +2,13 @@ import type { TuiPluginApi } from "@opencode-ai/plugin/tui";
 import type { Agent, PermissionRuleset } from "@opencode-ai/sdk/v2";
 import { DEFAULT_ALLOWED_TOOLS } from "./constants";
 import { formatResolvedModel } from "./model";
-import type { MiniConfig, ResolvedModel } from "./types";
+import type { MiniConfig, MiniMode, ResolvedModel } from "./types";
 
 const MINI_SIDE_QUESTION_INSTRUCTION =
   "You are answering a quick side question about an ongoing coding session. Below is the conversation context from the session. Answer concisely based on what you can see.";
+
+const MINI_FRESH_INSTRUCTION =
+  "You are answering a quick side question about an ongoing coding session. No conversation context from the main session has been copied into this mini session. Answer concisely based only on the current mini-session messages and any tools or files you inspect.";
 
 const ADDITIONAL_PERMISSION_IDS = [
   "edit",
@@ -173,18 +176,31 @@ export function buildResolvedMiniAgent(
 export function buildMiniSystemPrompt(
   context: string,
   resolved: ResolvedMiniAgent,
+  mode: MiniMode = "main",
 ) {
-  const intro = buildMiniSystemIntro(resolved);
+  const intro = buildMiniSystemIntro(resolved, mode);
   const toolNote =
     resolved.mode === "plugin-managed"
       ? buildAllowedToolSystemNote(resolved.allowedTools)
       : "";
 
-  return `${intro}${toolNote}\n\n<session-context>\n${context}\n</session-context>`;
+  const sessionContext = context.trim()
+    ? `\n\n<session-context>\n${context}\n</session-context>`
+    : "";
+
+  return `${intro}${toolNote}${sessionContext}`;
 }
 
-function buildMiniSystemIntro(resolved: ResolvedMiniAgent) {
-  if (resolved.mode !== "custom-agent") return MINI_SIDE_QUESTION_INSTRUCTION;
+function buildMiniSystemIntro(resolved: ResolvedMiniAgent, mode: MiniMode) {
+  if (resolved.mode !== "custom-agent") {
+    return mode === "fresh"
+      ? MINI_FRESH_INSTRUCTION
+      : MINI_SIDE_QUESTION_INSTRUCTION;
+  }
+
+  if (mode === "fresh") {
+    return `You are answering a quick side question about an ongoing coding session and you are running as the configured OpenCode agent "${resolved.agent}". Follow that agent's own instructions, role, tone, and constraints closely while answering this as a mini side question. No conversation context from the main session has been copied into this mini session.`;
+  }
 
   return `You are answering a quick side question about an ongoing coding session and you are running as the configured OpenCode agent "${resolved.agent}". Follow that agent's own instructions, role, tone, and constraints closely while answering this as a mini side question. Below is the conversation context from the session.`;
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,4 +1,5 @@
 import {
+  DEFAULT_FRESH_KEYBIND,
   DEFAULT_FULL_TOKEN_LIMIT,
   DEFAULT_KEYBIND,
   DEFAULT_TOGGLE_THINKING_KEYBIND,
@@ -19,6 +20,7 @@ export function parseConfig(options: unknown): MiniConfig {
       DEFAULT_FULL_TOKEN_LIMIT,
     ),
     keybind: parseKeybind(input.keybind, DEFAULT_KEYBIND),
+    freshKeybind: parseKeybind(input.freshKeybind, DEFAULT_FRESH_KEYBIND),
     enableThinking:
       typeof input.enableThinking === "boolean" ? input.enableThinking : false,
     toggleThinkingKeybind: parseKeybind(

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -2,6 +2,8 @@ export const PLUGIN_ID = "local.opencode-mini-session";
 
 export const CMD_OPEN = "mini.open";
 export const CMD_OPEN_FRESH = "mini.open-fresh";
+export const CMD_TOGGLE_MAIN = "mini.toggle-main";
+export const CMD_TOGGLE_FRESH = "mini.toggle-fresh";
 export const CMD_HIDE = "mini.hide";
 export const CMD_CLOSE = "mini.close";
 export const CMD_CONTINUE = "mini.continue";

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,6 +1,7 @@
 export const PLUGIN_ID = "local.opencode-mini-session";
 
 export const CMD_OPEN = "mini.open";
+export const CMD_OPEN_FRESH = "mini.open-fresh";
 export const CMD_HIDE = "mini.hide";
 export const CMD_CLOSE = "mini.close";
 export const CMD_CONTINUE = "mini.continue";
@@ -18,6 +19,7 @@ export const SCROLL_PAGE_DELTA = 14;
 
 export const DEFAULT_FULL_TOKEN_LIMIT = 50_000;
 export const DEFAULT_KEYBIND = "alt+b";
+export const DEFAULT_FRESH_KEYBIND = "alt+n";
 export const DEFAULT_TOGGLE_THINKING_KEYBIND = "ctrl+t";
 export const THINKING_TEXT = "Thinking...";
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -229,9 +229,7 @@ const tui: TuiPlugin = async (api, options, meta) => {
       action: nextAction,
       activeDialog,
       open: () => {
-        setOriginSessionID(sessionID);
-        activeMode = mode;
-        void openMiniSession(api, config, mode, setOverlay, {
+        const opened = openMiniSession(api, config, mode, setOverlay, {
           get: () => activeDialog,
           set: (dialog) => {
             activeDialog = dialog;
@@ -247,6 +245,10 @@ const tui: TuiPlugin = async (api, options, meta) => {
             modelPickerOpen = false;
             onAfterSelect();
           }), updateWarning);
+        if (opened) {
+          setOriginSessionID(sessionID);
+          activeMode = mode;
+        }
       },
     });
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,6 +8,7 @@ import {
   CMD_CONTINUE,
   CMD_HIDE,
   CMD_OPEN,
+  CMD_OPEN_FRESH,
   CMD_PAGE_DOWN,
   CMD_PAGE_UP,
   CMD_SCROLL_BOTTOM,
@@ -15,13 +16,17 @@ import {
   CMD_SCROLL_TOP,
   CMD_SCROLL_UP,
   CMD_TOGGLE_THINKING,
+  CMD_TOGGLE_FRESH,
+  CMD_TOGGLE_MAIN,
   PLUGIN_ID,
   SCROLL_LINE_DELTA,
   SCROLL_PAGE_DELTA,
 } from "./constants";
 import { openMiniSession, openModelPicker } from "./session";
+import { resolveMiniRouteAction } from "./routing";
 import type {
   ActiveDialogController,
+  MiniMode,
   ModelPreference,
   OverlayState,
   ThinkingPreferenceState,
@@ -31,6 +36,7 @@ import { startAutoUpdate } from "./update";
 const tui: TuiPlugin = async (api, options, meta) => {
   const config = parseConfig(options);
   const keybind = config.keybind;
+  const freshKeybind = config.freshKeybind;
   const [overlay, setOverlay] = createSignal<OverlayState | undefined>(
     undefined,
     { equals: false },
@@ -45,6 +51,7 @@ const tui: TuiPlugin = async (api, options, meta) => {
   const [originSessionID, setOriginSessionID] = createSignal<string | undefined>(undefined);
   const [updateWarning, setUpdateWarning] = createSignal<string | undefined>(undefined);
   let activeDialog: ActiveDialogController | undefined;
+  let activeMode: MiniMode | undefined;
   let modelPickerOpen = false;
   const thinkingPreference: ThinkingPreferenceState = {
     get: thinkingEnabled,
@@ -116,7 +123,6 @@ const tui: TuiPlugin = async (api, options, meta) => {
       },
     ],
     bindings: [
-      ...(keybind ? [{ key: keybind, cmd: CMD_HIDE }] : []),
       ...(config.toggleThinkingKeybind
         ? [{ key: config.toggleThinkingKeybind, cmd: CMD_TOGGLE_THINKING }]
         : []),
@@ -132,6 +138,18 @@ const tui: TuiPlugin = async (api, options, meta) => {
   api.keymap.registerLayer({
     commands: [
       {
+        name: CMD_TOGGLE_MAIN,
+        run() {
+          void triggerMiniMode("main", "keybind");
+        },
+      },
+      {
+        name: CMD_TOGGLE_FRESH,
+        run() {
+          void triggerMiniMode("fresh", "keybind");
+        },
+      },
+      {
         namespace: "palette",
         name: CMD_OPEN,
         title: "mini",
@@ -140,23 +158,19 @@ const tui: TuiPlugin = async (api, options, meta) => {
         slashName: "mini",
         enabled: () => api.route.current.name === "session",
         run() {
-          const currentRoute = api.route.current;
-          if (currentRoute.name !== "session") return;
-          const { sessionID } = currentRoute.params as { sessionID: string };
-          if (!activeDialog) setOriginSessionID(sessionID);
-          void openMiniSession(api, config, setOverlay, {
-            get: () => activeDialog,
-            set: (dialog) => {
-              activeDialog = dialog;
-              if (!dialog) setOriginSessionID(undefined);
-            },
-          }, {
-            get: selectedModel,
-            set: setSelectedModel,
-          }, thinkingPreference, (onAfterSelect) => openModelPicker(api, config, sessionID, { get: selectedModel, set: setSelectedModel }, () => {
-              modelPickerOpen = false;
-              onAfterSelect();
-            }), updateWarning);
+          void triggerMiniMode("main", "command");
+        },
+      },
+      {
+        namespace: "palette",
+        name: CMD_OPEN_FRESH,
+        title: "mini fresh",
+        desc: "Open a mini session without copied context",
+        category: "Plugin",
+        slashName: "mini-fresh",
+        enabled: () => api.route.current.name === "session",
+        run() {
+          void triggerMiniMode("fresh", "command");
         },
       },
       {
@@ -178,10 +192,72 @@ const tui: TuiPlugin = async (api, options, meta) => {
         },
       },
     ],
-    bindings: keybind
-      ? [{ key: keybind, cmd: CMD_OPEN, desc: "Open a mini session" }]
-      : [],
+    bindings: [
+      ...(keybind
+        ? [
+            {
+              key: keybind,
+              cmd: CMD_TOGGLE_MAIN,
+              desc: "Toggle main mini session",
+            },
+          ]
+        : []),
+      ...(freshKeybind
+        ? [
+            {
+              key: freshKeybind,
+              cmd: CMD_TOGGLE_FRESH,
+              desc: "Toggle fresh mini session",
+            },
+          ]
+        : []),
+    ],
   });
+
+  async function triggerMiniMode(mode: MiniMode, source: "command" | "keybind") {
+    const currentRoute = api.route.current;
+    if (currentRoute.name !== "session") return;
+    const { sessionID } = currentRoute.params as { sessionID: string };
+    const nextAction = resolveMiniRouteAction({
+      source,
+      requestedMode: mode,
+      activeMode,
+      isVisible: activeDialog?.isVisible(),
+    });
+
+    if (nextAction === "hide") {
+      activeDialog?.hide();
+      return;
+    }
+
+    if (nextAction === "show") {
+      activeDialog?.show();
+      return;
+    }
+
+    if (nextAction === "switch") {
+      await activeDialog?.close();
+    }
+
+    setOriginSessionID(sessionID);
+    activeMode = mode;
+    void openMiniSession(api, config, mode, setOverlay, {
+      get: () => activeDialog,
+      set: (dialog) => {
+        activeDialog = dialog;
+        if (!dialog) {
+          activeMode = undefined;
+          setOriginSessionID(undefined);
+        }
+      },
+    }, {
+      get: selectedModel,
+      set: setSelectedModel,
+    }, thinkingPreference, (onAfterSelect) => openModelPicker(api, config, sessionID, { get: selectedModel, set: setSelectedModel }, () => {
+        modelPickerOpen = false;
+        onAfterSelect();
+      }), updateWarning);
+  }
 };
 
 const plugin: TuiPluginModule & { id: string } = {

--- a/src/index.ts
+++ b/src/index.ts
@@ -23,7 +23,7 @@ import {
   SCROLL_PAGE_DELTA,
 } from "./constants";
 import { openMiniSession, openModelPicker } from "./session";
-import { resolveMiniRouteAction } from "./routing";
+import { resolveMiniRouteAction, runMiniRouteAction } from "./routing";
 import type {
   ActiveDialogController,
   MiniMode,
@@ -225,38 +225,30 @@ const tui: TuiPlugin = async (api, options, meta) => {
       isVisible: activeDialog?.isVisible(),
     });
 
-    if (nextAction === "hide") {
-      activeDialog?.hide();
-      return;
-    }
-
-    if (nextAction === "show") {
-      activeDialog?.show();
-      return;
-    }
-
-    if (nextAction === "switch") {
-      await activeDialog?.close();
-    }
-
-    setOriginSessionID(sessionID);
-    activeMode = mode;
-    void openMiniSession(api, config, mode, setOverlay, {
-      get: () => activeDialog,
-      set: (dialog) => {
-        activeDialog = dialog;
-        if (!dialog) {
-          activeMode = undefined;
-          setOriginSessionID(undefined);
-        }
+    await runMiniRouteAction({
+      action: nextAction,
+      activeDialog,
+      open: () => {
+        setOriginSessionID(sessionID);
+        activeMode = mode;
+        void openMiniSession(api, config, mode, setOverlay, {
+          get: () => activeDialog,
+          set: (dialog) => {
+            activeDialog = dialog;
+            if (!dialog) {
+              activeMode = undefined;
+              setOriginSessionID(undefined);
+            }
+          },
+        }, {
+          get: selectedModel,
+          set: setSelectedModel,
+        }, thinkingPreference, (onAfterSelect) => openModelPicker(api, config, sessionID, { get: selectedModel, set: setSelectedModel }, () => {
+            modelPickerOpen = false;
+            onAfterSelect();
+          }), updateWarning);
       },
-    }, {
-      get: selectedModel,
-      set: setSelectedModel,
-    }, thinkingPreference, (onAfterSelect) => openModelPicker(api, config, sessionID, { get: selectedModel, set: setSelectedModel }, () => {
-        modelPickerOpen = false;
-        onAfterSelect();
-      }), updateWarning);
+    });
   }
 };
 

--- a/src/routing.ts
+++ b/src/routing.ts
@@ -1,0 +1,16 @@
+import type { MiniMode } from "./types";
+
+export type MiniTriggerSource = "command" | "keybind";
+export type MiniRouteAction = "open" | "show" | "hide" | "switch";
+
+export function resolveMiniRouteAction(options: {
+  source: MiniTriggerSource;
+  requestedMode: MiniMode;
+  activeMode?: MiniMode;
+  isVisible?: boolean;
+}): MiniRouteAction {
+  if (!options.activeMode) return "open";
+  if (options.activeMode !== options.requestedMode) return "switch";
+  if (options.isVisible === false) return "show";
+  return options.source === "keybind" ? "hide" : "show";
+}

--- a/src/routing.ts
+++ b/src/routing.ts
@@ -3,6 +3,12 @@ import type { MiniMode } from "./types";
 export type MiniTriggerSource = "command" | "keybind";
 export type MiniRouteAction = "open" | "show" | "hide" | "switch";
 
+type MiniRouteController = {
+  close: () => Promise<void>;
+  hide: () => void;
+  show: () => void;
+};
+
 export function resolveMiniRouteAction(options: {
   source: MiniTriggerSource;
   requestedMode: MiniMode;
@@ -13,4 +19,26 @@ export function resolveMiniRouteAction(options: {
   if (options.activeMode !== options.requestedMode) return "switch";
   if (options.isVisible === false) return "show";
   return options.source === "keybind" ? "hide" : "show";
+}
+
+export async function runMiniRouteAction(options: {
+  action: MiniRouteAction;
+  activeDialog?: MiniRouteController;
+  open: () => void;
+}) {
+  if (options.action === "hide") {
+    options.activeDialog?.hide();
+    return;
+  }
+
+  if (options.action === "show") {
+    options.activeDialog?.show();
+    return;
+  }
+
+  if (options.action === "switch") {
+    await options.activeDialog?.close();
+  }
+
+  options.open();
 }

--- a/src/session.ts
+++ b/src/session.ts
@@ -387,7 +387,18 @@ export async function startQuestion(
   active.set(controller);
   renderOverlay({ focusInput: true });
 
-  resolvedAgent = await resolveRuntimeMiniAgent(api, config);
+  try {
+    resolvedAgent = await resolveRuntimeMiniAgent(api, config);
+  } catch (cause) {
+    if (closed) return;
+    api.ui.toast({
+      variant: "error",
+      message: `Failed to open mini session: ${getErrorMessage(cause)}`,
+    });
+    await cleanup();
+    return;
+  }
+
   if (closed) return;
   system = buildMiniSystemPrompt(context, resolvedAgent, mode);
   dialogState.notice = formatMiniNotice(

--- a/src/session.ts
+++ b/src/session.ts
@@ -46,7 +46,7 @@ type ErrorPath =
   | "session.create throw";
 
 
-export async function openMiniSession(
+export function openMiniSession(
   api: TuiPluginApi,
   config: MiniConfig,
   mode: MiniMode,
@@ -56,7 +56,7 @@ export async function openMiniSession(
   thinkingPreference: ThinkingPreferenceState,
   openPickerFn: (onAfterSelect: () => void) => void,
   getUpdateWarning?: () => string | undefined,
-) {
+): boolean {
   const currentRoute = api.route.current;
 
   if (currentRoute.name !== "session") {
@@ -64,13 +64,13 @@ export async function openMiniSession(
       variant: "error",
       message: "mini only works inside a session.",
     });
-    return;
+    return false;
   }
 
   const activeDialog = active.get();
   if (activeDialog) {
     activeDialog.show();
-    return;
+    return false;
   }
 
   const { sessionID } = currentRoute.params as { sessionID: string };
@@ -80,12 +80,13 @@ export async function openMiniSession(
     mode,
     sessionID,
     setOverlay,
-      active,
-      modelPreference,
-      thinkingPreference,
-      openPickerFn,
-      getUpdateWarning,
-    );
+    active,
+    modelPreference,
+    thinkingPreference,
+    openPickerFn,
+    getUpdateWarning,
+  );
+  return true;
 }
 
 export async function startQuestion(

--- a/src/session.ts
+++ b/src/session.ts
@@ -12,6 +12,7 @@ import {
   buildMiniSystemPrompt,
   formatMiniNotice,
   resolveRuntimeMiniAgent,
+  type ResolvedMiniAgent,
 } from "./agent";
 import { getSessionEntries, formatFullContext } from "./context";
 import { getErrorMessage } from "./diagnostics";
@@ -102,8 +103,6 @@ export async function startQuestion(
   const entries = getSessionEntries(api, sessionID);
   const context =
     mode === "main" ? formatFullContext(entries, config.tokenLimit) : "";
-  const resolvedAgent = await resolveRuntimeMiniAgent(api, config);
-  const system = buildMiniSystemPrompt(context, resolvedAgent, mode);
   const defaultResolvedModel = resolveDefaultModel(
     api.state.provider,
     config.model,
@@ -117,6 +116,8 @@ export async function startQuestion(
   const hiddenCommand = mode === "fresh" ? "/mini-fresh" : "/mini";
   const title = mode === "fresh" ? "mini fresh" : "mini session";
   const previousFocus = api.renderer.currentFocusedRenderable;
+  let resolvedAgent: ResolvedMiniAgent;
+  let system = "";
 
   const dialogState: AnswerDialogState = {
     entries: [],
@@ -127,10 +128,7 @@ export async function startQuestion(
     thinkingEnabled: thinkingPreference.get(),
     expandedThinkingPartIDs: {},
     update: getUpdateWarning?.(),
-    notice: formatMiniNotice(
-      defaultResolvedModel.notice,
-      ...resolvedAgent.notices,
-    ),
+    notice: undefined,
     errorDetail: undefined,
     messageModels: {},
   };
@@ -388,6 +386,15 @@ export async function startQuestion(
 
   active.set(controller);
   renderOverlay({ focusInput: true });
+
+  resolvedAgent = await resolveRuntimeMiniAgent(api, config);
+  if (closed) return;
+  system = buildMiniSystemPrompt(context, resolvedAgent, mode);
+  dialogState.notice = formatMiniNotice(
+    defaultResolvedModel.notice,
+    ...resolvedAgent.notices,
+  );
+  renderOverlay();
 
   function submitPrompt(value: string) {
     const prompt = value.trim();

--- a/src/session.ts
+++ b/src/session.ts
@@ -24,6 +24,7 @@ import type {
   ActiveDialog,
   AnswerDialogState,
   MiniConfig,
+  MiniMode,
   ModelPreferenceState,
   OverlayState,
   ResolvedModel,
@@ -47,6 +48,7 @@ type ErrorPath =
 export async function openMiniSession(
   api: TuiPluginApi,
   config: MiniConfig,
+  mode: MiniMode,
   setOverlay: Setter<OverlayState | undefined>,
   active: ActiveDialog,
   modelPreference: ModelPreferenceState,
@@ -74,6 +76,7 @@ export async function openMiniSession(
   void startQuestion(
     api,
     config,
+    mode,
     sessionID,
     setOverlay,
       active,
@@ -87,6 +90,7 @@ export async function openMiniSession(
 export async function startQuestion(
   api: TuiPluginApi,
   config: MiniConfig,
+  mode: MiniMode,
   sessionID: string,
   setOverlay: Setter<OverlayState | undefined>,
   active: ActiveDialog,
@@ -96,9 +100,10 @@ export async function startQuestion(
   getUpdateWarning?: () => string | undefined,
 ) {
   const entries = getSessionEntries(api, sessionID);
-  const context = formatFullContext(entries, config.tokenLimit);
+  const context =
+    mode === "main" ? formatFullContext(entries, config.tokenLimit) : "";
   const resolvedAgent = await resolveRuntimeMiniAgent(api, config);
-  const system = buildMiniSystemPrompt(context, resolvedAgent);
+  const system = buildMiniSystemPrompt(context, resolvedAgent, mode);
   const defaultResolvedModel = resolveDefaultModel(
     api.state.provider,
     config.model,
@@ -108,7 +113,9 @@ export async function startQuestion(
   const getResolvedModel = () =>
     modelPreference.get() ?? defaultResolvedModel.model;
   const getModelName = () => formatResolvedModel(getResolvedModel());
-  const hideKey = config.keybind;
+  const hideKey = mode === "fresh" ? config.freshKeybind : config.keybind;
+  const hiddenCommand = mode === "fresh" ? "/mini-fresh" : "/mini";
+  const title = mode === "fresh" ? "mini fresh" : "mini session";
   const previousFocus = api.renderer.currentFocusedRenderable;
 
   const dialogState: AnswerDialogState = {
@@ -219,7 +226,7 @@ export async function startQuestion(
       variant: "info",
       message: hideKey
         ? `mini hidden. Press ${hideKey} to show it.`
-        : "mini hidden. Run /mini to show it.",
+        : `mini hidden. Run ${hiddenCommand} to show it.`,
       duration: 1000,
     });
   };
@@ -316,7 +323,7 @@ export async function startQuestion(
     if (hidden) return;
     setOverlay({
       api,
-      title: "mini session",
+      title,
       version,
       modelName: getModelName(),
       hideKey,

--- a/src/types.ts
+++ b/src/types.ts
@@ -8,11 +8,14 @@ export type MiniConfig = {
   agent: string | null;
   tokenLimit: number;
   keybind: string | false;
+  freshKeybind: string | false;
   enableThinking: boolean;
   toggleThinkingKeybind: string | false;
   allowedTools: string[] | null;
   allowedToolsProvided: boolean;
 };
+
+export type MiniMode = "main" | "fresh";
 
 export type SessionEntry = {
   info: Message;

--- a/tests/agent.test.ts
+++ b/tests/agent.test.ts
@@ -17,6 +17,7 @@ function config(overrides: Partial<MiniConfig> = {}): MiniConfig {
     agent: null,
     tokenLimit: 50_000,
     keybind: "alt+b",
+    freshKeybind: "alt+n",
     enableThinking: false,
     toggleThinkingKeybind: "ctrl+t",
     allowedTools: null,
@@ -100,6 +101,15 @@ describe("config parsing", () => {
   it("disables the main keybind with false or none", () => {
     expect(parseConfig({ keybind: false }).keybind).toBe(false);
     expect(parseConfig({ keybind: "none" }).keybind).toBe(false);
+  });
+
+  it("parses fresh keybind values", () => {
+    expect(parseConfig({}).freshKeybind).toBe("alt+n");
+    expect(parseConfig({ freshKeybind: " alt+f " }).freshKeybind).toBe(
+      "alt+f",
+    );
+    expect(parseConfig({ freshKeybind: false }).freshKeybind).toBe(false);
+    expect(parseConfig({ freshKeybind: "none" }).freshKeybind).toBe(false);
   });
 });
 
@@ -232,6 +242,17 @@ describe("system prompts", () => {
     expect(prompt).not.toContain("configured OpenCode agent");
   });
 
+  it("omits session context tags in fresh plugin-managed mode", () => {
+    const resolved = resolveMiniAgent(config(), [], ["read"]);
+    const prompt = buildMiniSystemPrompt("", resolved, "fresh");
+
+    expect(prompt).toContain(
+      "No conversation context from the main session has been copied into this mini session.",
+    );
+    expect(prompt).not.toContain("<session-context>");
+    expect(prompt).toContain("You may only use the following tools");
+  });
+
   it("includes custom agent guidance without tool wording in custom-agent mode", () => {
     const resolved = resolveMiniAgent(
       config({ agent: "build" }),
@@ -244,6 +265,24 @@ describe("system prompts", () => {
       'You are answering a quick side question about an ongoing coding session and you are running as the configured OpenCode agent "build". Follow that agent\'s own instructions, role, tone, and constraints closely while answering this as a mini side question. Below is the conversation context from the session.',
     );
     expect(prompt).toContain("<session-context>\nmain context\n</session-context>");
+    expect(prompt).not.toContain("You may only use the following tools");
+  });
+
+  it("uses fresh custom-agent wording without context tags", () => {
+    const resolved = resolveMiniAgent(
+      config({ agent: "build" }),
+      [agent("build")],
+      ["read"],
+    );
+    const prompt = buildMiniSystemPrompt("", resolved, "fresh");
+
+    expect(prompt).toContain(
+      'You are answering a quick side question about an ongoing coding session and you are running as the configured OpenCode agent "build".',
+    );
+    expect(prompt).toContain(
+      "No conversation context from the main session has been copied into this mini session.",
+    );
+    expect(prompt).not.toContain("<session-context>");
     expect(prompt).not.toContain("You may only use the following tools");
   });
 });

--- a/tests/routing.test.ts
+++ b/tests/routing.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from "vitest";
+import { resolveMiniRouteAction } from "../src/routing";
+
+describe("mini routing", () => {
+  it("opens when no mini session is active", () => {
+    expect(
+      resolveMiniRouteAction({
+        source: "keybind",
+        requestedMode: "main",
+      }),
+    ).toBe("open");
+  });
+
+  it("hides the visible active mode from its keybind", () => {
+    expect(
+      resolveMiniRouteAction({
+        source: "keybind",
+        requestedMode: "fresh",
+        activeMode: "fresh",
+        isVisible: true,
+      }),
+    ).toBe("hide");
+  });
+
+  it("shows the hidden active mode from its keybind", () => {
+    expect(
+      resolveMiniRouteAction({
+        source: "keybind",
+        requestedMode: "main",
+        activeMode: "main",
+        isVisible: false,
+      }),
+    ).toBe("show");
+  });
+
+  it("switches when the other mode is requested", () => {
+    expect(
+      resolveMiniRouteAction({
+        source: "keybind",
+        requestedMode: "main",
+        activeMode: "fresh",
+        isVisible: true,
+      }),
+    ).toBe("switch");
+  });
+
+  it("shows instead of hiding when the same command is rerun", () => {
+    expect(
+      resolveMiniRouteAction({
+        source: "command",
+        requestedMode: "main",
+        activeMode: "main",
+        isVisible: true,
+      }),
+    ).toBe("show");
+  });
+});

--- a/tests/routing.test.ts
+++ b/tests/routing.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { resolveMiniRouteAction } from "../src/routing";
+import { resolveMiniRouteAction, runMiniRouteAction } from "../src/routing";
 
 describe("mini routing", () => {
   it("opens when no mini session is active", () => {
@@ -53,5 +53,35 @@ describe("mini routing", () => {
         isVisible: true,
       }),
     ).toBe("show");
+  });
+
+  it("waits for close before opening the other mode", async () => {
+    const events: string[] = [];
+    let finishClose: (() => void) | undefined;
+
+    const close = new Promise<void>((resolve) => {
+      finishClose = () => {
+        events.push("closed");
+        resolve();
+      };
+    });
+
+    const run = runMiniRouteAction({
+      action: "switch",
+      activeDialog: {
+        close: async () => {
+          events.push("closing");
+          await close;
+        },
+        hide: () => events.push("hide"),
+        show: () => events.push("show"),
+      },
+      open: () => events.push("open"),
+    });
+
+    expect(events).toEqual(["closing"]);
+    finishClose?.();
+    await run;
+    expect(events).toEqual(["closing", "closed", "open"]);
   });
 });

--- a/tests/session.test.ts
+++ b/tests/session.test.ts
@@ -1,0 +1,130 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const { resolveRuntimeMiniAgent } = vi.hoisted(() => ({
+  resolveRuntimeMiniAgent: vi.fn(),
+}));
+
+vi.mock("../src/agent", async () => {
+  const actual = await vi.importActual<typeof import("../src/agent")>(
+    "../src/agent",
+  );
+  return {
+    ...actual,
+    resolveRuntimeMiniAgent,
+  };
+});
+
+vi.mock("../src/context", () => ({
+  getSessionEntries: vi.fn(() => []),
+  formatFullContext: vi.fn(() => "main context"),
+}));
+
+import { startQuestion } from "../src/session";
+import type {
+  ActiveDialogController,
+  MiniConfig,
+  ModelPreferenceState,
+  ThinkingPreferenceState,
+} from "../src/types";
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((done) => {
+    resolve = done;
+  });
+  return { promise, resolve };
+}
+
+function config(): MiniConfig {
+  return {
+    model: null,
+    variant: null,
+    agent: null,
+    tokenLimit: 50_000,
+    keybind: "alt+b",
+    freshKeybind: "alt+n",
+    enableThinking: false,
+    toggleThinkingKeybind: "ctrl+t",
+    allowedTools: null,
+    allowedToolsProvided: false,
+  };
+}
+
+function fakeApi() {
+  return {
+    state: {
+      provider: [],
+      path: { directory: "/tmp/project" },
+    },
+    renderer: {
+      currentFocusedRenderable: undefined,
+      requestRender: vi.fn(),
+    },
+    ui: {
+      toast: vi.fn(),
+    },
+    client: {
+      session: {
+        abort: vi.fn(),
+        delete: vi.fn(),
+      },
+    },
+  } as any;
+}
+
+afterEach(() => {
+  resolveRuntimeMiniAgent.mockReset();
+});
+
+describe("startQuestion", () => {
+  it("registers an active controller before agent resolution completes", async () => {
+    const agentResolution = deferred<any>();
+    resolveRuntimeMiniAgent.mockReturnValue(agentResolution.promise);
+
+    const api = fakeApi();
+    let activeDialog: ActiveDialogController | undefined;
+    const active = {
+      get: () => activeDialog,
+      set: (dialog: ActiveDialogController | undefined) => {
+        activeDialog = dialog;
+      },
+    };
+    const modelPreference: ModelPreferenceState = {
+      get: () => undefined,
+      set: vi.fn(),
+    };
+    const thinkingPreference: ThinkingPreferenceState = {
+      get: () => false,
+      set: vi.fn(),
+    };
+
+    const opening = startQuestion(
+      api,
+      config(),
+      "main",
+      "session-1",
+      vi.fn(),
+      active,
+      modelPreference,
+      thinkingPreference,
+      vi.fn(),
+    );
+
+    await Promise.resolve();
+    expect(activeDialog).toBeDefined();
+
+    await activeDialog?.close();
+    agentResolution.resolve({
+      mode: "plugin-managed",
+      requestedAgent: null,
+      agent: null,
+      allowedTools: ["read"],
+      permission: [],
+      permissionSource: "plugin-managed",
+      notices: [],
+    });
+
+    await opening;
+    expect(activeDialog).toBeUndefined();
+  });
+});

--- a/tests/session.test.ts
+++ b/tests/session.test.ts
@@ -20,7 +20,7 @@ vi.mock("../src/context", () => ({
   formatFullContext,
 }));
 
-import { startQuestion } from "../src/session";
+import { openMiniSession, startQuestion } from "../src/session";
 import type {
   ActiveDialogController,
   MiniConfig,
@@ -75,12 +75,70 @@ function fakeApi() {
     event: {
       on: vi.fn(() => () => {}),
     },
+    route: {
+      current: { name: "session", params: { sessionID: "session-1" } },
+    },
   } as any;
 }
 
 afterEach(() => {
   formatFullContext.mockClear();
   resolveRuntimeMiniAgent.mockReset();
+});
+
+describe("openMiniSession", () => {
+  it("returns false and shows the active dialog when one is already open", () => {
+    const activeDialog = {
+      show: vi.fn(),
+    } as any;
+
+    const opened = openMiniSession(
+      fakeApi(),
+      config(),
+      "main",
+      vi.fn(),
+      { get: () => activeDialog, set: vi.fn() },
+      { get: () => undefined, set: vi.fn() },
+      { get: () => false, set: vi.fn() },
+      vi.fn(),
+    );
+
+    expect(opened).toBe(false);
+    expect(activeDialog.show).toHaveBeenCalledOnce();
+  });
+
+  it("returns true after creating a new dialog", () => {
+    resolveRuntimeMiniAgent.mockReturnValue({
+      mode: "plugin-managed",
+      requestedAgent: null,
+      agent: null,
+      allowedTools: ["read"],
+      permission: [],
+      permissionSource: "plugin-managed",
+      notices: [],
+    });
+
+    let activeDialog: ActiveDialogController | undefined;
+
+    const opened = openMiniSession(
+      fakeApi(),
+      config(),
+      "main",
+      vi.fn(),
+      {
+        get: () => activeDialog,
+        set: (dialog: ActiveDialogController | undefined) => {
+          activeDialog = dialog;
+        },
+      },
+      { get: () => undefined, set: vi.fn() },
+      { get: () => false, set: vi.fn() },
+      vi.fn(),
+    );
+
+    expect(opened).toBe(true);
+    expect(activeDialog).toBeDefined();
+  });
 });
 
 describe("startQuestion", () => {

--- a/tests/session.test.ts
+++ b/tests/session.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 
-const { resolveRuntimeMiniAgent } = vi.hoisted(() => ({
+const { formatFullContext, resolveRuntimeMiniAgent } = vi.hoisted(() => ({
+  formatFullContext: vi.fn(() => "main context"),
   resolveRuntimeMiniAgent: vi.fn(),
 }));
 
@@ -16,7 +17,7 @@ vi.mock("../src/agent", async () => {
 
 vi.mock("../src/context", () => ({
   getSessionEntries: vi.fn(() => []),
-  formatFullContext: vi.fn(() => "main context"),
+  formatFullContext,
 }));
 
 import { startQuestion } from "../src/session";
@@ -66,13 +67,19 @@ function fakeApi() {
     client: {
       session: {
         abort: vi.fn(),
+        create: vi.fn(async () => ({ data: { id: "mini-session" } })),
         delete: vi.fn(),
+        promptAsync: vi.fn(),
       },
+    },
+    event: {
+      on: vi.fn(() => () => {}),
     },
   } as any;
 }
 
 afterEach(() => {
+  formatFullContext.mockClear();
   resolveRuntimeMiniAgent.mockReset();
 });
 
@@ -126,5 +133,117 @@ describe("startQuestion", () => {
 
     await opening;
     expect(activeDialog).toBeUndefined();
+  });
+
+  it("skips copied context formatting in fresh mode", async () => {
+    const agentResolution = deferred<any>();
+    resolveRuntimeMiniAgent.mockReturnValue(agentResolution.promise);
+
+    const opening = startQuestion(
+      fakeApi(),
+      config(),
+      "fresh",
+      "session-1",
+      vi.fn(),
+      { get: () => undefined, set: vi.fn() },
+      { get: () => undefined, set: vi.fn() },
+      { get: () => false, set: vi.fn() },
+      vi.fn(),
+    );
+
+    await Promise.resolve();
+    expect(formatFullContext).not.toHaveBeenCalled();
+
+    agentResolution.resolve({
+      mode: "plugin-managed",
+      requestedAgent: null,
+      agent: null,
+      allowedTools: ["read"],
+      permission: [],
+      permissionSource: "plugin-managed",
+      notices: [],
+    });
+
+    await opening;
+  });
+
+  it("uses the fresh keybind in the hide toast", async () => {
+    const agentResolution = deferred<any>();
+    resolveRuntimeMiniAgent.mockReturnValue(agentResolution.promise);
+
+    const api = fakeApi();
+    let activeDialog: ActiveDialogController | undefined;
+
+    const opening = startQuestion(
+      api,
+      config(),
+      "fresh",
+      "session-1",
+      vi.fn(),
+      {
+        get: () => activeDialog,
+        set: (dialog: ActiveDialogController | undefined) => {
+          activeDialog = dialog;
+        },
+      },
+      { get: () => undefined, set: vi.fn() },
+      { get: () => false, set: vi.fn() },
+      vi.fn(),
+    );
+
+    await Promise.resolve();
+    activeDialog?.hide();
+
+    expect(api.ui.toast).toHaveBeenCalledWith(
+      expect.objectContaining({
+        message: "mini hidden. Press alt+n to show it.",
+      }),
+    );
+
+    agentResolution.resolve({
+      mode: "plugin-managed",
+      requestedAgent: null,
+      agent: null,
+      allowedTools: ["read"],
+      permission: [],
+      permissionSource: "plugin-managed",
+      notices: [],
+    });
+
+    await opening;
+  });
+
+  it("closes and shows an error if agent resolution fails", async () => {
+    const api = fakeApi();
+    let activeDialog: ActiveDialogController | undefined;
+
+    resolveRuntimeMiniAgent.mockRejectedValue(new Error("agent lookup failed"));
+
+    const opening = startQuestion(
+      api,
+      config(),
+      "main",
+      "session-1",
+      vi.fn(),
+      {
+        get: () => activeDialog,
+        set: (dialog: ActiveDialogController | undefined) => {
+          activeDialog = dialog;
+        },
+      },
+      { get: () => undefined, set: vi.fn() },
+      { get: () => false, set: vi.fn() },
+      vi.fn(),
+    );
+
+    await opening;
+
+    expect(activeDialog).toBeUndefined();
+    expect(api.ui.toast).toHaveBeenCalledWith(
+      expect.objectContaining({
+        variant: "error",
+        message: "Failed to open mini session: agent lookup failed",
+      }),
+    );
   });
 });


### PR DESCRIPTION
## Summary
- add a second mini session mode opened by /mini-fresh and freshKeybind
- keep main mini behavior unchanged while sharing the same overlay and session pipeline
- add coverage for prompt generation, routing, startup races, and fresh-mode behavior

## Testing
- npm test
- npm run typecheck

Fixes #5