### PR TITLE
Add mini session context counter and redesign footer

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,30 @@ Oldest messages are dropped to fit the `tokenLimit`, and the result is injected 
 
 Fresh mini mode skips this copied-context step entirely.
 
+## Footer counters
+
+The footer now shows two different context counters:
+
+1. Copied context, the main-session context injected when `/mini` opens
+2. Mini-session context, the exact `tokens.input` value reported by the SDK after each completed mini-session response
+
+Behavior differs by mode:
+
+- `/mini` opens with only the copied-context counter, shown as `used / tokenLimit`
+- `/mini-fresh` opens with no counter
+- After the first completed response, `/mini` shows `mini-session (percent) | copied-context / tokenLimit`
+- After the first completed response, `/mini-fresh` shows only the mini-session counter
+
+When the selected model has a known context window:
+
+- Mini-session context warns above 85 percent
+- The input placeholder changes near 95 percent to warn that the session context limit has been reached
+- The plugin does not block input, it only warns
+
+When the selected model context window is unavailable, the footer shows absolute token counts only, with no percentages or threshold-based warnings.
+
+If copied context reaches the configured `tokenLimit` cap, the limit value in the footer is highlighted.
+
 ## Troubleshooting
 
 ### Force update from older versions

--- a/README.md
+++ b/README.md
@@ -121,30 +121,6 @@ Oldest messages are dropped to fit the `tokenLimit`, and the result is injected 
 
 Fresh mini mode skips this copied-context step entirely.
 
-## Footer counters
-
-The footer now shows two different context counters:
-
-1. Copied context, the main-session context injected when `/mini` opens
-2. Mini-session context, the exact `tokens.input` value reported by the SDK after each completed mini-session response
-
-Behavior differs by mode:
-
-- `/mini` opens with only the copied-context counter, shown as `used / tokenLimit`
-- `/mini-fresh` opens with no counter
-- After the first completed response, `/mini` shows `mini-session (percent) | copied-context / tokenLimit`
-- After the first completed response, `/mini-fresh` shows only the mini-session counter
-
-When the selected model has a known context window:
-
-- Mini-session context warns above 85 percent
-- The input placeholder changes near 95 percent to warn that the session context limit has been reached
-- The plugin does not block input, it only warns
-
-When the selected model context window is unavailable, the footer shows absolute token counts only, with no percentages or threshold-based warnings.
-
-If copied context reaches the configured `tokenLimit` cap, the limit value in the footer is highlighted.
-
 ## Troubleshooting
 
 ### Force update from older versions

--- a/src/components/AnswerDialog.tsx
+++ b/src/components/AnswerDialog.tsx
@@ -16,7 +16,6 @@ import type {
 } from "../types";
 import { extractAssistantText } from "../session";
 import { ActionButton } from "./ActionButton";
-import { HintBar, type HintBarItem } from "./HintBar";
 
 function buildSyntaxStyle(
   theme: TuiPluginApi["theme"]["current"],
@@ -90,12 +89,12 @@ export function AnswerDialog(props: AnswerDialogProps) {
   const screenHeight = props.api.renderer.height;
   const panelWidth = Math.min(100, Math.floor(screenWidth * 0.85));
   const panelHeight = Math.max(
-    12,
+    14,
     Math.min(screenHeight - 6, Math.floor(screenHeight * 0.68)),
   );
   const transcriptWidth = Math.max(20, panelWidth - 6);
-  const compactFooter = transcriptWidth < 70;
-  const transcriptHeight = Math.max(1, panelHeight - (compactFooter ? 13 : 11));
+  const promptContentWidth = Math.max(10, transcriptWidth - 6);
+  const transcriptHeight = Math.max(1, panelHeight - 13);
   const transcriptContentWidth = Math.max(20, transcriptWidth - 5);
 
   const messages = createMemo(() => buildMiniMessages(props.state));
@@ -129,23 +128,15 @@ export function AnswerDialog(props: AnswerDialogProps) {
   const hasFooterCounter = createMemo(
     () => Boolean(footerCounter().miniSession || footerCounter().copiedContext),
   );
-  const hintItems = createMemo<HintBarItem[]>(() =>
-    canContinue()
-      ? [
-          { keybind: "enter", label: "send" },
-          { keybind: "shift+enter", label: "continue" },
-          { keybind: "esc", label: "close" },
-        ]
-      : [
-          { keybind: "enter", label: "send" },
-          { keybind: "tab", label: "model" },
-          { keybind: "esc", label: "close" },
-        ],
-  );
   const footerModelName = createMemo(() =>
     truncateWithEllipsis(
       props.modelName,
-      Math.max(0, transcriptWidth - getHintBarWidth(hintItems()) - 3),
+      Math.max(
+        0,
+        promptContentWidth -
+          getFooterCounterWidth(footerCounter()) -
+          (hasFooterCounter() ? 3 : 0),
+      ),
     ),
   );
 
@@ -292,90 +283,96 @@ export function AnswerDialog(props: AnswerDialogProps) {
           paddingLeft={3}
           paddingRight={3}
           paddingBottom={1}
-          paddingTop={1}
           flexDirection="column"
           gap={1}
           marginTop={1}
-          backgroundColor={theme.borderSubtle}
         >
-          <input
-            ref={(node) => {
-              input = node;
-              props.onInput?.(node);
-            }}
-            width={transcriptWidth}
-            placeholder={
-              props.state.inputPlaceholder ??
-              (props.state.loading
-                ? "Waiting for response..."
-                : "Ask a question...")
-            }
-            textColor={theme.text}
-            placeholderColor={theme.textMuted}
-            backgroundColor={theme.backgroundPanel}
-            focusedTextColor={theme.text}
-            cursorColor={theme.primary}
-            focusedBackgroundColor={theme.backgroundPanel}
-            onInput={(value) => {
-              inputValue = value;
-            }}
-            onSubmit={() => {
-              const submitted = (input?.value || inputValue).trim();
-              if (!submitted || props.state.loading) return;
-              if (!props.onSubmit(submitted)) return;
-              inputValue = "";
-              if (input) input.value = "";
-            }}
-          />
           <box
-            flexDirection="row"
-            justifyContent="space-between"
-            alignItems="center"
             width={transcriptWidth}
-            gap={3}
+            height={6}
+            backgroundColor={theme.borderSubtle}
+            flexDirection="column"
+            paddingTop={1}
+            paddingLeft={2}
+            paddingRight={2}
+            paddingBottom={1}
+            justifyContent="space-between"
           >
-            <box flexDirection="row" gap={2}>
-              <Show when={canContinue()}>
-                <ActionButton
-                  api={props.api}
-                  label="Continue"
-                  onPress={props.onContinue}
-                />
+            <input
+              ref={(node) => {
+                input = node;
+                props.onInput?.(node);
+              }}
+              width={promptContentWidth}
+              placeholder={
+                props.state.inputPlaceholder ??
+                (props.state.loading
+                  ? "Waiting for response..."
+                  : "Ask a question...")
+              }
+              textColor={theme.text}
+              placeholderColor={theme.textMuted}
+              backgroundColor={theme.borderSubtle}
+              focusedTextColor={theme.text}
+              cursorColor={theme.primary}
+              focusedBackgroundColor={theme.borderSubtle}
+              onInput={(value) => {
+                inputValue = value;
+              }}
+              onSubmit={() => {
+                const submitted = (input?.value || inputValue).trim();
+                if (!submitted || props.state.loading) return;
+                if (!props.onSubmit(submitted)) return;
+                inputValue = "";
+                if (input) input.value = "";
+              }}
+            />
+            <box
+              flexDirection="row"
+              justifyContent="space-between"
+              alignItems="center"
+              width={promptContentWidth}
+              gap={3}
+            >
+              <text fg={theme.text}>{footerModelName()}</text>
+              <Show when={hasFooterCounter()}>
+                <FooterCounter api={props.api} state={footerCounter()} />
               </Show>
-              <ActionButton
-                api={props.api}
-                label="Hide"
-                onPress={props.onHide}
-              />
-              <ActionButton
-                api={props.api}
-                label="Think"
-                onPress={props.onToggleThinking}
-              />
-              <ActionButton
-                api={props.api}
-                label="Model"
-                onPress={props.onChangeModel}
-              />
             </box>
-            <Show when={!compactFooter && hasFooterCounter()}>
-              <FooterCounter api={props.api} state={footerCounter()} />
-            </Show>
           </box>
-          <Show when={compactFooter && hasFooterCounter()}>
-            <box flexDirection="row" justifyContent="flex-end" width={transcriptWidth}>
-              <FooterCounter api={props.api} state={footerCounter()} />
-            </box>
-          </Show>
           <box
             flexDirection="row"
-            justifyContent="space-between"
+            justifyContent="flex-end"
             alignItems="center"
             width={transcriptWidth}
-            gap={3}
+            gap={2}
           >
-            <text fg={theme.textMuted}>{footerModelName()}</text>
-            <HintBar api={props.api} items={hintItems()} />
+            <Show when={canContinue()}>
+              <ActionButton
+                api={props.api}
+                label="Continue"
+                keybind="shift+enter"
+                onPress={props.onContinue}
+              />
+            </Show>
+            <ActionButton
+              api={props.api}
+              label="Toggle"
+              keybind={props.hideKey || undefined}
+              onPress={props.onHide}
+            />
+            <ActionButton
+              api={props.api}
+              label="Thinking"
+              keybind={props.toggleThinkingKeybind || undefined}
+              onPress={props.onToggleThinking}
+            />
+            <ActionButton
+              api={props.api}
+              label="Model"
+              keybind="tab"
+              onPress={props.onChangeModel}
+            />
           </box>
         </box>
       </box>
@@ -718,15 +715,11 @@ function truncateWithEllipsis(text: string, maxWidth: number) {
   return `${text.slice(0, maxWidth - 3)}...`;
 }
 
-function getHintBarWidth(items: HintBarItem[]) {
-  if (items.length === 0) return 0;
-  return (
-    items.reduce(
-      (total, item) => total + (item.keybind ? item.keybind.length : 0) + item.label.length + 1,
-      0,
-    ) +
-    (items.length - 1) * 2
-  );
+function getFooterCounterWidth(state: AnswerDialogState["footerCounter"]) {
+  const miniWidth = state.miniSession?.text.length ?? 0;
+  const copiedWidth = state.copiedContext?.text.length ?? 0;
+  if (miniWidth && copiedWidth) return miniWidth + copiedWidth + 3;
+  return miniWidth + copiedWidth;
 }
 
 function getReasoningPartID(part: Extract<Part, { type: "reasoning" }>) {

--- a/src/components/AnswerDialog.tsx
+++ b/src/components/AnswerDialog.tsx
@@ -7,7 +7,6 @@ import {
 import type { TuiPluginApi } from "@opencode-ai/plugin/tui";
 import type { Part } from "@opencode-ai/sdk/v2";
 import { createMemo, Show } from "solid-js";
-import { formatTokenCount } from "../counter";
 import { THINKING_TEXT } from "../constants";
 import type {
   AnswerDialogProps,
@@ -690,18 +689,13 @@ function FooterCounter(props: {
         )}
       </Show>
       <Show when={props.state.miniSession && props.state.copiedContext}>
-        <text fg={theme.primary}>·</text>
+        <text fg={theme.textMuted}>·</text>
       </Show>
       <Show when={props.state.copiedContext}>
         {(copiedContext) => (
-          <box flexDirection="row" gap={0}>
-            <text fg={theme.textMuted}>
-              {formatTokenCount(copiedContext().usedTokens)} /{" "}
-            </text>
-            <text fg={copiedContext().capReached ? theme.warning : theme.textMuted}>
-              {formatTokenCount(copiedContext().tokenLimit)}
-            </text>
-          </box>
+          <text fg={copiedContext().truncated ? theme.warning : theme.textMuted}>
+            {copiedContext().text}
+          </text>
         )}
       </Show>
     </box>

--- a/src/components/AnswerDialog.tsx
+++ b/src/components/AnswerDialog.tsx
@@ -690,7 +690,7 @@ function FooterCounter(props: {
         )}
       </Show>
       <Show when={props.state.miniSession && props.state.copiedContext}>
-        <text fg={theme.textMuted}>|</text>
+        <text fg={theme.primary}>·</text>
       </Show>
       <Show when={props.state.copiedContext}>
         {(copiedContext) => (

--- a/src/components/AnswerDialog.tsx
+++ b/src/components/AnswerDialog.tsx
@@ -93,7 +93,7 @@ export function AnswerDialog(props: AnswerDialogProps) {
     12,
     Math.min(screenHeight - 6, Math.floor(screenHeight * 0.68)),
   );
-  const transcriptHeight = Math.max(5, panelHeight - 12);
+  const transcriptHeight = Math.max(4, panelHeight - 13);
   const transcriptWidth = Math.max(20, panelWidth - 6);
   const transcriptContentWidth = Math.max(20, transcriptWidth - 5);
 
@@ -133,6 +133,9 @@ export function AnswerDialog(props: AnswerDialogProps) {
     { keybind: props.hideKey, label: "hide" },
     { keybind: "esc", label: "close" },
   ]);
+  const footerModelName = createMemo(() =>
+    truncateWithEllipsis(props.modelName, Math.max(12, Math.floor(transcriptWidth * 0.42))),
+  );
 
   return (
     <box
@@ -353,7 +356,7 @@ export function AnswerDialog(props: AnswerDialogProps) {
             width={transcriptWidth}
             gap={3}
           >
-            <text fg={theme.textMuted}>{props.modelName}</text>
+            <text fg={theme.textMuted}>{footerModelName()}</text>
             <FooterCounter api={props.api} state={footerCounter()} />
           </box>
           <HintBar api={props.api} items={hintItems()} />
@@ -689,42 +692,6 @@ function FooterCounter(props: {
       </Show>
     </box>
   );
-}
-
-function formatFooterModelName(
-  modelName: string,
-  options: {
-    width: number;
-    canContinue: boolean;
-    hideKey: string | false;
-    toggleThinkingKeybind: string | false;
-  },
-) {
-  const actionWidth = getFooterActionsWidth(options);
-  const maxWidth = Math.max(0, options.width - actionWidth - 4);
-  return truncateWithEllipsis(modelName, maxWidth);
-}
-
-function getFooterActionsWidth(options: {
-  canContinue: boolean;
-  hideKey: string | false;
-  toggleThinkingKeybind: string | false;
-}) {
-  const actions = [
-    options.canContinue
-      ? getActionButtonWidth("Continue", "shift+enter")
-      : 0,
-    getActionButtonWidth("Toggle", options.hideKey),
-    getActionButtonWidth("Thinking", options.toggleThinkingKeybind),
-    getActionButtonWidth("Model", "tab"),
-  ].filter((width) => width > 0);
-
-  if (actions.length === 0) return 0;
-  return actions.reduce((total, width) => total + width, 0) + (actions.length - 1) * 2;
-}
-
-function getActionButtonWidth(label: string, keybind?: string | false) {
-  return label.length + (keybind ? keybind.length + 1 : 0);
 }
 
 function truncateWithEllipsis(text: string, maxWidth: number) {

--- a/src/components/AnswerDialog.tsx
+++ b/src/components/AnswerDialog.tsx
@@ -7,6 +7,7 @@ import {
 import type { TuiPluginApi } from "@opencode-ai/plugin/tui";
 import type { Part } from "@opencode-ai/sdk/v2";
 import { createMemo, Show } from "solid-js";
+import { formatTokenCount } from "../counter";
 import { THINKING_TEXT } from "../constants";
 import type {
   AnswerDialogProps,
@@ -15,7 +16,7 @@ import type {
 } from "../types";
 import { extractAssistantText } from "../session";
 import { ActionButton } from "./ActionButton";
-import { HintBar } from "./HintBar";
+import { HintBar, type HintBarItem } from "./HintBar";
 
 function buildSyntaxStyle(
   theme: TuiPluginApi["theme"]["current"],
@@ -92,7 +93,7 @@ export function AnswerDialog(props: AnswerDialogProps) {
     12,
     Math.min(screenHeight - 6, Math.floor(screenHeight * 0.68)),
   );
-  const transcriptHeight = Math.max(5, panelHeight - 10);
+  const transcriptHeight = Math.max(5, panelHeight - 12);
   const transcriptWidth = Math.max(20, panelWidth - 6);
   const transcriptContentWidth = Math.max(20, transcriptWidth - 5);
 
@@ -123,14 +124,15 @@ export function AnswerDialog(props: AnswerDialogProps) {
   const createUserMessageHint = createMemo(() =>
     getCreateUserMessageHint(props.state),
   );
-  const footerModelName = createMemo(() =>
-    formatFooterModelName(props.modelName, {
-      width: transcriptWidth,
-      canContinue: canContinue(),
-      hideKey: props.hideKey,
-      toggleThinkingKeybind: props.toggleThinkingKeybind,
-    }),
-  );
+  const footerCounter = createMemo(() => props.state.footerCounter);
+  const hintItems = createMemo<HintBarItem[]>(() => [
+    { keybind: "enter", label: "send" },
+    { keybind: canContinue() ? "shift+enter" : false, label: "continue" },
+    { keybind: "tab", label: "model" },
+    { keybind: props.toggleThinkingKeybind, label: "thinking" },
+    { keybind: props.hideKey, label: "hide" },
+    { keybind: "esc", label: "close" },
+  ]);
 
   return (
     <box
@@ -163,7 +165,7 @@ export function AnswerDialog(props: AnswerDialogProps) {
           paddingLeft={3}
           paddingRight={3}
           flexDirection="row"
-          justifyContent="space-between"
+          justifyContent="flex-start"
           alignItems="center"
           marginBottom={1}
         >
@@ -175,7 +177,6 @@ export function AnswerDialog(props: AnswerDialogProps) {
               {(version) => <text fg={theme.textMuted}>{version()}</text>}
             </Show>
           </box>
-          <HintBar api={props.api} hideKey={props.hideKey} />
         </box>
         {/* transcript */}
         <box paddingLeft={3} paddingRight={3}>
@@ -272,19 +273,50 @@ export function AnswerDialog(props: AnswerDialogProps) {
             </box>
           </scrollbox>
         </box>
-        {/* separator */}
-        <text marginTop={1} fg={theme.borderSubtle}>
-          {"─".repeat(panelWidth)}
-        </text>
-        {/* input + actions */}
         <box
           paddingLeft={3}
           paddingRight={3}
           paddingBottom={1}
+          paddingTop={1}
           flexDirection="column"
           gap={1}
           marginTop={1}
+          backgroundColor={theme.borderSubtle}
         >
+          <box
+            flexDirection="row"
+            justifyContent="flex-start"
+            alignItems="center"
+            width={transcriptWidth}
+            gap={2}
+          >
+            <Show when={canContinue()}>
+              <ActionButton
+                api={props.api}
+                label="Continue"
+                keybind="shift+enter"
+                onPress={props.onContinue}
+              />
+            </Show>
+            <ActionButton
+              api={props.api}
+              label="Toggle"
+              keybind={props.hideKey || undefined}
+              onPress={props.onHide}
+            />
+            <ActionButton
+              api={props.api}
+              label="Thinking"
+              keybind={props.toggleThinkingKeybind || undefined}
+              onPress={props.onToggleThinking}
+            />
+            <ActionButton
+              api={props.api}
+              label="Model"
+              keybind="tab"
+              onPress={props.onChangeModel}
+            />
+          </box>
           <input
             ref={(node) => {
               input = node;
@@ -292,9 +324,10 @@ export function AnswerDialog(props: AnswerDialogProps) {
             }}
             width={transcriptWidth}
             placeholder={
-              props.state.loading
+              props.state.inputPlaceholder ??
+              (props.state.loading
                 ? "Waiting for response..."
-                : "Ask a question..."
+                : "Ask a question...")
             }
             textColor={theme.text}
             placeholderColor={theme.textMuted}
@@ -313,43 +346,17 @@ export function AnswerDialog(props: AnswerDialogProps) {
               if (input) input.value = "";
             }}
           />
-            <box
-              flexDirection="row"
-              justifyContent="space-between"
-              alignItems="center"
-              width={transcriptWidth}
-              gap={3}
-            >
-            <box flexDirection="row" gap={2}>
-              <Show when={canContinue()}>
-                <ActionButton
-                  api={props.api}
-                  label="Continue"
-                  keybind="shift+enter"
-                  onPress={props.onContinue}
-                />
-              </Show>
-              <ActionButton
-                api={props.api}
-                label="Toggle"
-                keybind={props.hideKey || undefined}
-                onPress={props.onHide}
-              />
-              <ActionButton
-                api={props.api}
-                label="Thinking"
-                keybind={props.toggleThinkingKeybind || undefined}
-                onPress={props.onToggleThinking}
-              />
-              <ActionButton
-                api={props.api}
-                label="Model"
-                keybind="tab"
-                onPress={props.onChangeModel}
-              />
-            </box>
-            <text fg={theme.textMuted}>{footerModelName()}</text>
+          <box
+            flexDirection="row"
+            justifyContent="space-between"
+            alignItems="center"
+            width={transcriptWidth}
+            gap={3}
+          >
+            <text fg={theme.textMuted}>{props.modelName}</text>
+            <FooterCounter api={props.api} state={footerCounter()} />
           </box>
+          <HintBar api={props.api} items={hintItems()} />
         </box>
       </box>
     </box>
@@ -646,6 +653,42 @@ function summarizeToolInput(
 
 function formatMiniPart(part: MiniPart) {
   return part.text;
+}
+
+function FooterCounter(props: {
+  api: TuiPluginApi;
+  state: AnswerDialogState["footerCounter"];
+}) {
+  const theme = props.api.theme.current;
+
+  if (!props.state.miniSession && !props.state.copiedContext) return <text />;
+
+  return (
+    <box flexDirection="row" gap={1}>
+      <Show when={props.state.miniSession}>
+        {(miniSession) => (
+          <text fg={miniSession().warning ? theme.warning : theme.textMuted}>
+            {miniSession().text}
+          </text>
+        )}
+      </Show>
+      <Show when={props.state.miniSession && props.state.copiedContext}>
+        <text fg={theme.textMuted}>|</text>
+      </Show>
+      <Show when={props.state.copiedContext}>
+        {(copiedContext) => (
+          <box flexDirection="row" gap={0}>
+            <text fg={theme.textMuted}>
+              {formatTokenCount(copiedContext().usedTokens)} /{" "}
+            </text>
+            <text fg={copiedContext().capReached ? theme.warning : theme.textMuted}>
+              {formatTokenCount(copiedContext().tokenLimit)}
+            </text>
+          </box>
+        )}
+      </Show>
+    </box>
+  );
 }
 
 function formatFooterModelName(

--- a/src/components/AnswerDialog.tsx
+++ b/src/components/AnswerDialog.tsx
@@ -93,8 +93,9 @@ export function AnswerDialog(props: AnswerDialogProps) {
     12,
     Math.min(screenHeight - 6, Math.floor(screenHeight * 0.68)),
   );
-  const transcriptHeight = Math.max(4, panelHeight - 13);
   const transcriptWidth = Math.max(20, panelWidth - 6);
+  const compactFooter = transcriptWidth < 70;
+  const transcriptHeight = Math.max(1, panelHeight - (compactFooter ? 13 : 11));
   const transcriptContentWidth = Math.max(20, transcriptWidth - 5);
 
   const messages = createMemo(() => buildMiniMessages(props.state));
@@ -125,16 +126,27 @@ export function AnswerDialog(props: AnswerDialogProps) {
     getCreateUserMessageHint(props.state),
   );
   const footerCounter = createMemo(() => props.state.footerCounter);
-  const hintItems = createMemo<HintBarItem[]>(() => [
-    { keybind: "enter", label: "send" },
-    { keybind: canContinue() ? "shift+enter" : false, label: "continue" },
-    { keybind: "tab", label: "model" },
-    { keybind: props.toggleThinkingKeybind, label: "thinking" },
-    { keybind: props.hideKey, label: "hide" },
-    { keybind: "esc", label: "close" },
-  ]);
+  const hasFooterCounter = createMemo(
+    () => Boolean(footerCounter().miniSession || footerCounter().copiedContext),
+  );
+  const hintItems = createMemo<HintBarItem[]>(() =>
+    canContinue()
+      ? [
+          { keybind: "enter", label: "send" },
+          { keybind: "shift+enter", label: "continue" },
+          { keybind: "esc", label: "close" },
+        ]
+      : [
+          { keybind: "enter", label: "send" },
+          { keybind: "tab", label: "model" },
+          { keybind: "esc", label: "close" },
+        ],
+  );
   const footerModelName = createMemo(() =>
-    truncateWithEllipsis(props.modelName, Math.max(12, Math.floor(transcriptWidth * 0.42))),
+    truncateWithEllipsis(
+      props.modelName,
+      Math.max(0, transcriptWidth - getHintBarWidth(hintItems()) - 3),
+    ),
   );
 
   return (
@@ -286,40 +298,6 @@ export function AnswerDialog(props: AnswerDialogProps) {
           marginTop={1}
           backgroundColor={theme.borderSubtle}
         >
-          <box
-            flexDirection="row"
-            justifyContent="flex-start"
-            alignItems="center"
-            width={transcriptWidth}
-            gap={2}
-          >
-            <Show when={canContinue()}>
-              <ActionButton
-                api={props.api}
-                label="Continue"
-                keybind="shift+enter"
-                onPress={props.onContinue}
-              />
-            </Show>
-            <ActionButton
-              api={props.api}
-              label="Toggle"
-              keybind={props.hideKey || undefined}
-              onPress={props.onHide}
-            />
-            <ActionButton
-              api={props.api}
-              label="Thinking"
-              keybind={props.toggleThinkingKeybind || undefined}
-              onPress={props.onToggleThinking}
-            />
-            <ActionButton
-              api={props.api}
-              label="Model"
-              keybind="tab"
-              onPress={props.onChangeModel}
-            />
-          </box>
           <input
             ref={(node) => {
               input = node;
@@ -356,10 +334,49 @@ export function AnswerDialog(props: AnswerDialogProps) {
             width={transcriptWidth}
             gap={3}
           >
-            <text fg={theme.textMuted}>{footerModelName()}</text>
-            <FooterCounter api={props.api} state={footerCounter()} />
+            <box flexDirection="row" gap={2}>
+              <Show when={canContinue()}>
+                <ActionButton
+                  api={props.api}
+                  label="Continue"
+                  onPress={props.onContinue}
+                />
+              </Show>
+              <ActionButton
+                api={props.api}
+                label="Hide"
+                onPress={props.onHide}
+              />
+              <ActionButton
+                api={props.api}
+                label="Think"
+                onPress={props.onToggleThinking}
+              />
+              <ActionButton
+                api={props.api}
+                label="Model"
+                onPress={props.onChangeModel}
+              />
+            </box>
+            <Show when={!compactFooter && hasFooterCounter()}>
+              <FooterCounter api={props.api} state={footerCounter()} />
+            </Show>
           </box>
-          <HintBar api={props.api} items={hintItems()} />
+          <Show when={compactFooter && hasFooterCounter()}>
+            <box flexDirection="row" justifyContent="flex-end" width={transcriptWidth}>
+              <FooterCounter api={props.api} state={footerCounter()} />
+            </box>
+          </Show>
+          <box
+            flexDirection="row"
+            justifyContent="space-between"
+            alignItems="center"
+            width={transcriptWidth}
+            gap={3}
+          >
+            <text fg={theme.textMuted}>{footerModelName()}</text>
+            <HintBar api={props.api} items={hintItems()} />
+          </box>
         </box>
       </box>
     </box>
@@ -699,6 +716,17 @@ function truncateWithEllipsis(text: string, maxWidth: number) {
   if (text.length <= maxWidth) return text;
   if (maxWidth <= 3) return ".".repeat(maxWidth);
   return `${text.slice(0, maxWidth - 3)}...`;
+}
+
+function getHintBarWidth(items: HintBarItem[]) {
+  if (items.length === 0) return 0;
+  return (
+    items.reduce(
+      (total, item) => total + (item.keybind ? item.keybind.length : 0) + item.label.length + 1,
+      0,
+    ) +
+    (items.length - 1) * 2
+  );
 }
 
 function getReasoningPartID(part: Extract<Part, { type: "reasoning" }>) {

--- a/src/components/HintBar.tsx
+++ b/src/components/HintBar.tsx
@@ -1,7 +1,27 @@
 /** @jsxImportSource @opentui/solid */
 import type { TuiPluginApi } from "@opencode-ai/plugin/tui";
+import { For } from "solid-js";
 
-export function HintBar(props: { api: TuiPluginApi; hideKey: string | false }) {
+export type HintBarItem = {
+  keybind: string | false;
+  label: string;
+};
+
+export function HintBar(props: {
+  api: TuiPluginApi;
+  items: HintBarItem[];
+}) {
   const theme = props.api.theme.current;
-  return <text fg={theme.textMuted}>esc</text>;
+
+  return (
+    <box flexDirection="row" gap={2}>
+      <For each={props.items.filter((item) => item.keybind)}>
+        {(item) => (
+          <text fg={theme.textMuted}>
+            <b>{item.keybind}</b> {item.label}
+          </text>
+        )}
+      </For>
+    </box>
+  );
 }

--- a/src/context.ts
+++ b/src/context.ts
@@ -13,6 +13,10 @@ export function getSessionEntries(
 }
 
 export function formatFullContext(entries: SessionEntry[], tokenLimit: number) {
+  return buildCopiedContext(entries, tokenLimit).text;
+}
+
+export function buildCopiedContext(entries: SessionEntry[], tokenLimit: number) {
   const selected: string[] = [];
   let usedTokens = 0;
 
@@ -29,8 +33,17 @@ export function formatFullContext(entries: SessionEntry[], tokenLimit: number) {
     if (usedTokens >= tokenLimit) break;
   }
 
-  if (selected.length === 0) return "No conversation context available.";
-  return selected.reverse().join("\n\n");
+  if (selected.length === 0) {
+    return {
+      text: "No conversation context available.",
+      usedTokens: 0,
+    };
+  }
+
+  return {
+    text: selected.reverse().join("\n\n"),
+    usedTokens,
+  };
 }
 
 function formatEntry(entry: SessionEntry) {

--- a/src/context.ts
+++ b/src/context.ts
@@ -17,18 +17,25 @@ export function formatFullContext(entries: SessionEntry[], tokenLimit: number) {
 }
 
 export function buildCopiedContext(entries: SessionEntry[], tokenLimit: number) {
+  const chunks = entries
+    .map((entry) => {
+      const text = formatEntry(entry);
+      return text ? { text, tokens: estimateTokens(text) } : undefined;
+    })
+    .filter((chunk): chunk is { text: string; tokens: number } => Boolean(chunk));
+  const totalAvailableTokens = chunks.reduce(
+    (total, chunk) => total + chunk.tokens,
+    0,
+  );
   const selected: string[] = [];
   let usedTokens = 0;
 
-  for (let index = entries.length - 1; index >= 0; index -= 1) {
-    const chunk = formatEntry(entries[index]);
-    if (!chunk) continue;
+  for (let index = chunks.length - 1; index >= 0; index -= 1) {
+    const chunk = chunks[index];
+    if (selected.length > 0 && usedTokens + chunk.tokens > tokenLimit) break;
 
-    const estimated = estimateTokens(chunk);
-    if (selected.length > 0 && usedTokens + estimated > tokenLimit) break;
-
-    selected.push(chunk);
-    usedTokens += estimated;
+    selected.push(chunk.text);
+    usedTokens += chunk.tokens;
 
     if (usedTokens >= tokenLimit) break;
   }
@@ -37,12 +44,14 @@ export function buildCopiedContext(entries: SessionEntry[], tokenLimit: number) 
     return {
       text: "No conversation context available.",
       usedTokens: 0,
+      totalAvailableTokens,
     };
   }
 
   return {
     text: selected.reverse().join("\n\n"),
     usedTokens,
+    totalAvailableTokens,
   };
 }
 

--- a/src/counter.ts
+++ b/src/counter.ts
@@ -35,6 +35,11 @@ export function getUsagePercent(usedTokens: number, limit: number) {
   return (usedTokens / limit) * 100;
 }
 
+export function getDisplayPercent(usedTokens: number, limit: number) {
+  const percent = getUsagePercent(usedTokens, limit);
+  return percent === undefined ? undefined : Math.round(percent);
+}
+
 export function isMiniSessionWarning(percentUsed?: number) {
   return Boolean(percentUsed !== undefined && percentUsed >= MINI_SESSION_WARNING_PERCENT);
 }
@@ -79,7 +84,7 @@ export function buildFooterCounterState(options: {
 function buildMiniSessionCounter(usedTokens: number, modelContextWindow?: number) {
   const percentUsed =
     modelContextWindow !== undefined
-      ? getUsagePercent(usedTokens, modelContextWindow)
+      ? getDisplayPercent(usedTokens, modelContextWindow)
       : undefined;
 
   return {

--- a/src/counter.ts
+++ b/src/counter.ts
@@ -6,9 +6,10 @@ export const MINI_SESSION_LIMIT_PERCENT = 95;
 export type FooterCounterState = {
   copiedContext?: {
     usedTokens: number;
+    totalAvailableTokens: number;
     tokenLimit: number;
     text: string;
-    capReached: boolean;
+    truncated: boolean;
   };
   miniSession?: {
     usedTokens: number;
@@ -51,17 +52,29 @@ export function isMiniSessionLimitReached(percentUsed?: number) {
 export function buildFooterCounterState(options: {
   mode: MiniMode;
   copiedContextTokens?: number;
+  copiedContextTotalTokens?: number;
   tokenLimit: number;
   lastCompletedMiniInputTokens?: number;
   modelContextWindow?: number;
 }): FooterCounterState {
+  const copiedContextTotalTokens =
+    options.copiedContextTotalTokens ?? options.copiedContextTokens;
+  const copiedContextTruncated =
+    options.copiedContextTokens !== undefined &&
+    copiedContextTotalTokens !== undefined &&
+    copiedContextTotalTokens > options.copiedContextTokens;
   const copiedContext =
     options.mode === "main" && options.copiedContextTokens !== undefined
       ? {
           usedTokens: options.copiedContextTokens,
+          totalAvailableTokens: copiedContextTotalTokens ?? options.copiedContextTokens,
           tokenLimit: options.tokenLimit,
-          text: `${formatTokenCount(options.copiedContextTokens)} / ${formatTokenCount(options.tokenLimit)}`,
-          capReached: options.copiedContextTokens >= options.tokenLimit,
+          text: formatCopiedContextCounter(
+            options.copiedContextTokens,
+            copiedContextTotalTokens ?? options.copiedContextTokens,
+            options.tokenLimit,
+          ),
+          truncated: copiedContextTruncated,
         }
       : undefined;
 
@@ -79,6 +92,15 @@ export function buildFooterCounterState(options: {
     placeholder:
       miniSession?.limitReached ? "Session context limit reached..." : undefined,
   };
+}
+
+function formatCopiedContextCounter(
+  usedTokens: number,
+  totalAvailableTokens: number,
+  tokenLimit: number,
+) {
+  if (totalAvailableTokens <= usedTokens) return `main ${formatTokenCount(usedTokens)}`;
+  return `main ${formatTokenCount(Math.min(usedTokens, tokenLimit))}/${formatTokenCount(totalAvailableTokens)}`;
 }
 
 function buildMiniSessionCounter(usedTokens: number, modelContextWindow?: number) {

--- a/src/counter.ts
+++ b/src/counter.ts
@@ -1,0 +1,95 @@
+import type { MiniMode } from "./types";
+
+export const MINI_SESSION_WARNING_PERCENT = 85;
+export const MINI_SESSION_LIMIT_PERCENT = 95;
+
+export type FooterCounterState = {
+  copiedContext?: {
+    usedTokens: number;
+    tokenLimit: number;
+    text: string;
+    capReached: boolean;
+  };
+  miniSession?: {
+    usedTokens: number;
+    percentUsed?: number;
+    text: string;
+    warning: boolean;
+    limitReached: boolean;
+  };
+  placeholder?: string;
+};
+
+export function formatTokenCount(value: number) {
+  if (value < 1000) return `${Math.round(value)}`;
+  if (value < 1_000_000) return `${(value / 1000).toFixed(1)}K`;
+  return `${(value / 1_000_000).toFixed(1)}M`;
+}
+
+export function formatPercent(value: number) {
+  return `${Math.round(value)}%`;
+}
+
+export function getUsagePercent(usedTokens: number, limit: number) {
+  if (limit <= 0) return undefined;
+  return (usedTokens / limit) * 100;
+}
+
+export function isMiniSessionWarning(percentUsed?: number) {
+  return Boolean(percentUsed !== undefined && percentUsed >= MINI_SESSION_WARNING_PERCENT);
+}
+
+export function isMiniSessionLimitReached(percentUsed?: number) {
+  return Boolean(percentUsed !== undefined && percentUsed >= MINI_SESSION_LIMIT_PERCENT);
+}
+
+export function buildFooterCounterState(options: {
+  mode: MiniMode;
+  copiedContextTokens?: number;
+  tokenLimit: number;
+  lastCompletedMiniInputTokens?: number;
+  modelContextWindow?: number;
+}): FooterCounterState {
+  const copiedContext =
+    options.mode === "main" && options.copiedContextTokens !== undefined
+      ? {
+          usedTokens: options.copiedContextTokens,
+          tokenLimit: options.tokenLimit,
+          text: `${formatTokenCount(options.copiedContextTokens)} / ${formatTokenCount(options.tokenLimit)}`,
+          capReached: options.copiedContextTokens >= options.tokenLimit,
+        }
+      : undefined;
+
+  const miniSession =
+    options.lastCompletedMiniInputTokens !== undefined
+      ? buildMiniSessionCounter(
+          options.lastCompletedMiniInputTokens,
+          options.modelContextWindow,
+        )
+      : undefined;
+
+  return {
+    copiedContext,
+    miniSession,
+    placeholder:
+      miniSession?.limitReached ? "Session context limit reached..." : undefined,
+  };
+}
+
+function buildMiniSessionCounter(usedTokens: number, modelContextWindow?: number) {
+  const percentUsed =
+    modelContextWindow !== undefined
+      ? getUsagePercent(usedTokens, modelContextWindow)
+      : undefined;
+
+  return {
+    usedTokens,
+    percentUsed,
+    text:
+      percentUsed !== undefined
+        ? `${formatTokenCount(usedTokens)} (${formatPercent(percentUsed)})`
+        : formatTokenCount(usedTokens),
+    warning: isMiniSessionWarning(percentUsed),
+    limitReached: isMiniSessionLimitReached(percentUsed),
+  };
+}

--- a/src/model.ts
+++ b/src/model.ts
@@ -97,3 +97,14 @@ export function formatResolvedModel(resolved: ResolvedModel) {
   const base = `${resolved.model.providerID}/${resolved.model.modelID}`;
   return resolved.variant ? `${base} (${resolved.variant})` : base;
 }
+
+export function resolveModelContextWindow(
+  providers: TuiPluginApi["state"]["provider"],
+  resolved: ResolvedModel,
+) {
+  const model = resolved.model;
+  if (!model) return undefined;
+  return providers.find((provider) => provider.id === model.providerID)?.models[
+    model.modelID
+  ]?.limit?.context;
+}

--- a/src/session.ts
+++ b/src/session.ts
@@ -5,6 +5,7 @@ import type {
 } from "@opencode-ai/plugin/tui";
 import type { Setter } from "solid-js";
 import { version } from "../package.json";
+import { buildFooterCounterState } from "./counter";
 import {
   buildMiniErrorDetail,
   buildMiniPromptPayload,
@@ -14,11 +15,12 @@ import {
   resolveRuntimeMiniAgent,
   type ResolvedMiniAgent,
 } from "./agent";
-import { getSessionEntries, formatFullContext } from "./context";
+import { buildCopiedContext, getSessionEntries } from "./context";
 import { getErrorMessage } from "./diagnostics";
 import {
   resolveDefaultModel,
   formatResolvedModel,
+  resolveModelContextWindow,
   type ModelSource,
 } from "./model";
 import type {
@@ -102,8 +104,11 @@ export async function startQuestion(
   getUpdateWarning?: () => string | undefined,
 ) {
   const entries = getSessionEntries(api, sessionID);
-  const context =
-    mode === "main" ? formatFullContext(entries, config.tokenLimit) : "";
+  const copiedContext =
+    mode === "main"
+      ? buildCopiedContext(entries, config.tokenLimit)
+      : { text: "", usedTokens: undefined };
+  const context = copiedContext.text;
   const defaultResolvedModel = resolveDefaultModel(
     api.state.provider,
     config.model,
@@ -121,11 +126,17 @@ export async function startQuestion(
   let system = "";
 
   const dialogState: AnswerDialogState = {
+    mode,
     entries: [],
     streamingAnswer: "",
     loading: false,
     scrollbarVisible: false,
     spinnerFrame: 0,
+    copiedContextTokens: copiedContext.usedTokens,
+    lastCompletedMiniInputTokens: undefined,
+    modelContextWindow: undefined,
+    footerCounter: {},
+    inputPlaceholder: undefined,
     thinkingEnabled: thinkingPreference.get(),
     expandedThinkingPartIDs: {},
     update: getUpdateWarning?.(),
@@ -152,6 +163,21 @@ export async function startQuestion(
   let pendingScrollToBottom = false;
   let lastScrollTop = 0;
   let lastScrollHeight = 0;
+
+  const syncCounterState = () => {
+    dialogState.modelContextWindow = resolveModelContextWindow(
+      api.state.provider,
+      getResolvedModel(),
+    );
+    dialogState.footerCounter = buildFooterCounterState({
+      mode: dialogState.mode,
+      copiedContextTokens: dialogState.copiedContextTokens,
+      tokenLimit: config.tokenLimit,
+      lastCompletedMiniInputTokens: dialogState.lastCompletedMiniInputTokens,
+      modelContextWindow: dialogState.modelContextWindow,
+    });
+    dialogState.inputPlaceholder = dialogState.footerCounter.placeholder;
+  };
 
   const clearScrollTimer = () => {
     pendingScrollToBottom = false;
@@ -359,6 +385,7 @@ export async function startQuestion(
 
   const renderOverlay = (options: { focusInput?: boolean } = {}) => {
     if (closed) return;
+    syncCounterState();
     const streamingActive =
       dialogState.loading || Boolean(dialogState.streamingAnswer);
     const currentScrollTop = overlayScroller?.scrollTop ?? 0;
@@ -553,6 +580,9 @@ export async function startQuestion(
         if (event.properties.sessionID !== tempSessionID) return;
         const usedModel = submissionModelQueue.shift();
         refreshSession();
+        dialogState.lastCompletedMiniInputTokens =
+          getLastCompletedMiniInputTokens(dialogState.entries) ??
+          dialogState.lastCompletedMiniInputTokens;
         if (usedModel) {
           for (const entry of dialogState.entries) {
             if (
@@ -755,4 +785,14 @@ function buildMiniSessionTranscript(state: AnswerDialogState) {
 
 function buildContinuePrompt(transcript: string) {
   return ["[Context from a mini session]", transcript, "---\n"].join("\n\n");
+}
+
+function getLastCompletedMiniInputTokens(entries: AnswerDialogState["entries"]) {
+  for (let index = entries.length - 1; index >= 0; index -= 1) {
+    const info = entries[index]?.info;
+    if (info.role !== "assistant") continue;
+    if (!info.time?.completed) continue;
+    if (typeof info.tokens?.input === "number") return info.tokens.input;
+  }
+  return undefined;
 }

--- a/src/session.ts
+++ b/src/session.ts
@@ -107,7 +107,7 @@ export async function startQuestion(
   const copiedContext =
     mode === "main"
       ? buildCopiedContext(entries, config.tokenLimit)
-      : { text: "", usedTokens: undefined };
+      : { text: "", usedTokens: undefined, totalAvailableTokens: undefined };
   const context = copiedContext.text;
   const defaultResolvedModel = resolveDefaultModel(
     api.state.provider,
@@ -133,6 +133,7 @@ export async function startQuestion(
     scrollbarVisible: false,
     spinnerFrame: 0,
     copiedContextTokens: copiedContext.usedTokens,
+    copiedContextTotalTokens: copiedContext.totalAvailableTokens,
     lastCompletedMiniInputTokens: undefined,
     modelContextWindow: undefined,
     footerCounter: {},
@@ -163,7 +164,8 @@ export async function startQuestion(
   let pendingScrollToBottom = false;
   let lastScrollTop = 0;
   let lastScrollHeight = 0;
-  let lastCompletedTokenMessageID: string | undefined;
+  let currentTokenMessageID: string | undefined;
+  const incrementedTokenMessageIDs = new Set<string>();
 
   const syncCounterState = () => {
     dialogState.modelContextWindow = resolveModelContextWindow(
@@ -173,6 +175,7 @@ export async function startQuestion(
     dialogState.footerCounter = buildFooterCounterState({
       mode: dialogState.mode,
       copiedContextTokens: dialogState.copiedContextTokens,
+      copiedContextTotalTokens: dialogState.copiedContextTotalTokens,
       tokenLimit: config.tokenLimit,
       lastCompletedMiniInputTokens: dialogState.lastCompletedMiniInputTokens,
       modelContextWindow: dialogState.modelContextWindow,
@@ -572,21 +575,23 @@ export async function startQuestion(
       if (!latest) return;
 
       const current = dialogState.lastCompletedMiniInputTokens;
-      if (latest.messageID === lastCompletedTokenMessageID) {
-        if (current === undefined || latest.totalTokens > current) {
-          dialogState.lastCompletedMiniInputTokens = latest.totalTokens;
-        }
-        return;
-      }
-
-      lastCompletedTokenMessageID = latest.messageID;
-
-      if (current === undefined || latest.totalTokens >= current) {
+      if (current === undefined || latest.totalTokens > current) {
         dialogState.lastCompletedMiniInputTokens = latest.totalTokens;
+        currentTokenMessageID = latest.messageID;
         return;
       }
 
+      if (latest.messageID === currentTokenMessageID) {
+        return;
+      }
+
+      if (incrementedTokenMessageIDs.has(latest.messageID)) {
+        return;
+      }
+
+      incrementedTokenMessageIDs.add(latest.messageID);
       dialogState.lastCompletedMiniInputTokens = current + latest.inputTokens;
+      currentTokenMessageID = latest.messageID;
     };
 
     if (closed) {

--- a/src/session.ts
+++ b/src/session.ts
@@ -163,6 +163,7 @@ export async function startQuestion(
   let pendingScrollToBottom = false;
   let lastScrollTop = 0;
   let lastScrollHeight = 0;
+  let lastCompletedTokenMessageID: string | undefined;
 
   const syncCounterState = () => {
     dialogState.modelContextWindow = resolveModelContextWindow(
@@ -563,6 +564,29 @@ export async function startQuestion(
     const refreshSession = () => {
       dialogState.entries = getSessionEntries(api, ephemeralSessionID);
       dialogState.streamingAnswer = "";
+      refreshLastCompletedMiniInputTokens();
+    };
+
+    const refreshLastCompletedMiniInputTokens = () => {
+      const latest = getLastCompletedMiniInputUsage(dialogState.entries);
+      if (!latest) return;
+
+      const current = dialogState.lastCompletedMiniInputTokens;
+      if (latest.messageID === lastCompletedTokenMessageID) {
+        if (current === undefined || latest.totalTokens > current) {
+          dialogState.lastCompletedMiniInputTokens = latest.totalTokens;
+        }
+        return;
+      }
+
+      lastCompletedTokenMessageID = latest.messageID;
+
+      if (current === undefined || latest.totalTokens >= current) {
+        dialogState.lastCompletedMiniInputTokens = latest.totalTokens;
+        return;
+      }
+
+      dialogState.lastCompletedMiniInputTokens = current + latest.inputTokens;
     };
 
     if (closed) {
@@ -580,9 +604,6 @@ export async function startQuestion(
         if (event.properties.sessionID !== tempSessionID) return;
         const usedModel = submissionModelQueue.shift();
         refreshSession();
-        dialogState.lastCompletedMiniInputTokens =
-          getLastCompletedMiniInputTokens(dialogState.entries) ??
-          dialogState.lastCompletedMiniInputTokens;
         if (usedModel) {
           for (const entry of dialogState.entries) {
             if (
@@ -787,12 +808,25 @@ function buildContinuePrompt(transcript: string) {
   return ["[Context from a mini session]", transcript, "---\n"].join("\n\n");
 }
 
-function getLastCompletedMiniInputTokens(entries: AnswerDialogState["entries"]) {
+function getLastCompletedMiniInputUsage(entries: AnswerDialogState["entries"]) {
   for (let index = entries.length - 1; index >= 0; index -= 1) {
     const info = entries[index]?.info;
     if (info.role !== "assistant") continue;
     if (!info.time?.completed) continue;
-    if (typeof info.tokens?.input === "number") return info.tokens.input;
+    if (info.tokens) {
+      return {
+        messageID: info.id,
+        inputTokens: info.tokens.input,
+        totalTokens: getAssistantInputTokens(info.tokens),
+      };
+    }
   }
   return undefined;
+}
+
+function getAssistantInputTokens(tokens: {
+  input: number;
+  cache?: { read?: number; write?: number };
+}) {
+  return tokens.input + (tokens.cache?.read ?? 0) + (tokens.cache?.write ?? 0);
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,6 +1,7 @@
 import type { InputRenderable, ScrollBoxRenderable } from "@opentui/core";
 import type { TuiPluginApi } from "@opencode-ai/plugin/tui";
 import type { Message, Part } from "@opencode-ai/sdk/v2";
+import type { FooterCounterState } from "./counter";
 
 export type MiniConfig = {
   model: string | null;
@@ -55,11 +56,17 @@ export type ActiveDialogController = {
 };
 
 export type AnswerDialogState = {
+  mode: MiniMode;
   entries: SessionEntry[];
   streamingAnswer: string;
   loading: boolean;
   scrollbarVisible: boolean;
   spinnerFrame: number;
+  copiedContextTokens?: number;
+  lastCompletedMiniInputTokens?: number;
+  modelContextWindow?: number;
+  footerCounter: FooterCounterState;
+  inputPlaceholder?: string;
   thinkingEnabled: boolean;
   expandedThinkingPartIDs: Record<string, true>;
   notice?: string;

--- a/src/types.ts
+++ b/src/types.ts
@@ -63,6 +63,7 @@ export type AnswerDialogState = {
   scrollbarVisible: boolean;
   spinnerFrame: number;
   copiedContextTokens?: number;
+  copiedContextTotalTokens?: number;
   lastCompletedMiniInputTokens?: number;
   modelContextWindow?: number;
   footerCounter: FooterCounterState;

--- a/tests/context.test.ts
+++ b/tests/context.test.ts
@@ -15,7 +15,8 @@ describe("copied context", () => {
 
     expect(buildCopiedContext(entries, 50)).toEqual({
       text: "user:\nhello\n\nassistant:\nworld",
-      usedTokens: estimateTokens("user:\nhello\n\nassistant:\nworld"),
+      usedTokens: estimateTokens("user:\nhello") + estimateTokens("assistant:\nworld"),
+      totalAvailableTokens: estimateTokens("user:\nhello") + estimateTokens("assistant:\nworld"),
     });
   });
 
@@ -26,6 +27,9 @@ describe("copied context", () => {
     expect(buildCopiedContext([older, newer], estimateTokens("assistant:\nnewest message stays"))).toEqual({
       text: "assistant:\nnewest message stays",
       usedTokens: estimateTokens("assistant:\nnewest message stays"),
+      totalAvailableTokens:
+        estimateTokens("user:\nold message that should be dropped") +
+        estimateTokens("assistant:\nnewest message stays"),
     });
   });
 
@@ -36,6 +40,7 @@ describe("copied context", () => {
 
     expect(result.text).toBe(`assistant:\n${"x".repeat(200)}`);
     expect(result.usedTokens).toBeGreaterThan(10);
+    expect(result.totalAvailableTokens).toBe(result.usedTokens);
   });
 
   it("keeps formatFullContext behavior stable", () => {

--- a/tests/context.test.ts
+++ b/tests/context.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+import { buildCopiedContext, estimateTokens, formatFullContext } from "../src/context";
+import type { SessionEntry } from "../src/types";
+
+function entry(role: "user" | "assistant", text: string): SessionEntry {
+  return {
+    info: { id: `${role}-${text}`, role } as SessionEntry["info"],
+    parts: [{ type: "text", text }],
+  } as SessionEntry;
+}
+
+describe("copied context", () => {
+  it("returns text and estimated token usage together", () => {
+    const entries = [entry("user", "hello"), entry("assistant", "world")];
+
+    expect(buildCopiedContext(entries, 50)).toEqual({
+      text: "user:\nhello\n\nassistant:\nworld",
+      usedTokens: estimateTokens("user:\nhello\n\nassistant:\nworld"),
+    });
+  });
+
+  it("keeps whole-message newest-first selection behavior", () => {
+    const older = entry("user", "old message that should be dropped");
+    const newer = entry("assistant", "newest message stays");
+
+    expect(buildCopiedContext([older, newer], estimateTokens("assistant:\nnewest message stays"))).toEqual({
+      text: "assistant:\nnewest message stays",
+      usedTokens: estimateTokens("assistant:\nnewest message stays"),
+    });
+  });
+
+  it("preserves the oversized newest message edge case", () => {
+    const newest = entry("assistant", "x".repeat(200));
+
+    const result = buildCopiedContext([newest], 10);
+
+    expect(result.text).toBe(`assistant:\n${"x".repeat(200)}`);
+    expect(result.usedTokens).toBeGreaterThan(10);
+  });
+
+  it("keeps formatFullContext behavior stable", () => {
+    const entries = [entry("user", "hello")];
+    expect(formatFullContext(entries, 50)).toBe("user:\nhello");
+  });
+});

--- a/tests/counter.test.ts
+++ b/tests/counter.test.ts
@@ -27,9 +27,10 @@ describe("counter helpers", () => {
     ).toEqual({
       copiedContext: {
         usedTokens: 31_000,
+        totalAvailableTokens: 31_000,
         tokenLimit: 50_000,
-        text: "31.0K / 50.0K",
-        capReached: false,
+        text: "main 31.0K",
+        truncated: false,
       },
       miniSession: undefined,
       placeholder: undefined,
@@ -48,9 +49,10 @@ describe("counter helpers", () => {
     ).toEqual({
       copiedContext: {
         usedTokens: 31_000,
+        totalAvailableTokens: 31_000,
         tokenLimit: 50_000,
-        text: "31.0K / 50.0K",
-        capReached: false,
+        text: "main 31.0K",
+        truncated: false,
       },
       miniSession: {
         usedTokens: 11_240,
@@ -84,11 +86,12 @@ describe("counter helpers", () => {
     });
   });
 
-  it("marks copied-context cap and mini-session threshold states", () => {
+  it("marks copied-context truncation and mini-session threshold states", () => {
     expect(
       buildFooterCounterState({
         mode: "main",
         copiedContextTokens: 50_000,
+        copiedContextTotalTokens: 80_000,
         tokenLimit: 50_000,
         lastCompletedMiniInputTokens: 96_000,
         modelContextWindow: 100_000,
@@ -96,9 +99,10 @@ describe("counter helpers", () => {
     ).toEqual({
       copiedContext: {
         usedTokens: 50_000,
+        totalAvailableTokens: 80_000,
         tokenLimit: 50_000,
-        text: "50.0K / 50.0K",
-        capReached: true,
+        text: "main 50.0K/80.0K",
+        truncated: true,
       },
       miniSession: {
         usedTokens: 96_000,
@@ -108,6 +112,23 @@ describe("counter helpers", () => {
         limitReached: true,
       },
       placeholder: "Session context limit reached...",
+    });
+  });
+
+  it("shows copied context as copied over total when truncated", () => {
+    expect(
+      buildFooterCounterState({
+        mode: "main",
+        copiedContextTokens: 1_400,
+        copiedContextTotalTokens: 3_200,
+        tokenLimit: 1_400,
+      }).copiedContext,
+    ).toEqual({
+      usedTokens: 1_400,
+      totalAvailableTokens: 3_200,
+      tokenLimit: 1_400,
+      text: "main 1.4K/3.2K",
+      truncated: true,
     });
   });
 

--- a/tests/counter.test.ts
+++ b/tests/counter.test.ts
@@ -54,7 +54,7 @@ describe("counter helpers", () => {
       },
       miniSession: {
         usedTokens: 11_240,
-        percentUsed: 7.025,
+        percentUsed: 7,
         text: "11.2K (7%)",
         warning: false,
         limitReached: false,
@@ -108,6 +108,23 @@ describe("counter helpers", () => {
         limitReached: true,
       },
       placeholder: "Session context limit reached...",
+    });
+  });
+
+  it("applies thresholds using the displayed rounded percentage", () => {
+    expect(
+      buildFooterCounterState({
+        mode: "fresh",
+        tokenLimit: 50_000,
+        lastCompletedMiniInputTokens: 84_600,
+        modelContextWindow: 100_000,
+      }).miniSession,
+    ).toEqual({
+      usedTokens: 84_600,
+      percentUsed: 85,
+      text: "84.6K (85%)",
+      warning: true,
+      limitReached: false,
     });
   });
 });

--- a/tests/counter.test.ts
+++ b/tests/counter.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildFooterCounterState,
+  formatPercent,
+  formatTokenCount,
+} from "../src/counter";
+
+describe("counter helpers", () => {
+  it("formats token counts in compact footer form", () => {
+    expect(formatTokenCount(912)).toBe("912");
+    expect(formatTokenCount(11_240)).toBe("11.2K");
+    expect(formatTokenCount(50_000)).toBe("50.0K");
+  });
+
+  it("formats percentages for footer display", () => {
+    expect(formatPercent(6.8)).toBe("7%");
+    expect(formatPercent(85.1)).toBe("85%");
+  });
+
+  it("shows copied context only before the first main-mode response", () => {
+    expect(
+      buildFooterCounterState({
+        mode: "main",
+        copiedContextTokens: 31_000,
+        tokenLimit: 50_000,
+      }),
+    ).toEqual({
+      copiedContext: {
+        usedTokens: 31_000,
+        tokenLimit: 50_000,
+        text: "31.0K / 50.0K",
+        capReached: false,
+      },
+      miniSession: undefined,
+      placeholder: undefined,
+    });
+  });
+
+  it("shows mini-session and copied-context counters together after completion", () => {
+    expect(
+      buildFooterCounterState({
+        mode: "main",
+        copiedContextTokens: 31_000,
+        tokenLimit: 50_000,
+        lastCompletedMiniInputTokens: 11_240,
+        modelContextWindow: 160_000,
+      }),
+    ).toEqual({
+      copiedContext: {
+        usedTokens: 31_000,
+        tokenLimit: 50_000,
+        text: "31.0K / 50.0K",
+        capReached: false,
+      },
+      miniSession: {
+        usedTokens: 11_240,
+        percentUsed: 7.025,
+        text: "11.2K (7%)",
+        warning: false,
+        limitReached: false,
+      },
+      placeholder: undefined,
+    });
+  });
+
+  it("hides copied context in fresh mode and falls back to absolute mini tokens when needed", () => {
+    expect(
+      buildFooterCounterState({
+        mode: "fresh",
+        copiedContextTokens: 31_000,
+        tokenLimit: 50_000,
+        lastCompletedMiniInputTokens: 11_240,
+      }),
+    ).toEqual({
+      copiedContext: undefined,
+      miniSession: {
+        usedTokens: 11_240,
+        percentUsed: undefined,
+        text: "11.2K",
+        warning: false,
+        limitReached: false,
+      },
+      placeholder: undefined,
+    });
+  });
+
+  it("marks copied-context cap and mini-session threshold states", () => {
+    expect(
+      buildFooterCounterState({
+        mode: "main",
+        copiedContextTokens: 50_000,
+        tokenLimit: 50_000,
+        lastCompletedMiniInputTokens: 96_000,
+        modelContextWindow: 100_000,
+      }),
+    ).toEqual({
+      copiedContext: {
+        usedTokens: 50_000,
+        tokenLimit: 50_000,
+        text: "50.0K / 50.0K",
+        capReached: true,
+      },
+      miniSession: {
+        usedTokens: 96_000,
+        percentUsed: 96,
+        text: "96.0K (96%)",
+        warning: true,
+        limitReached: true,
+      },
+      placeholder: "Session context limit reached...",
+    });
+  });
+});

--- a/tests/model.test.ts
+++ b/tests/model.test.ts
@@ -1,6 +1,6 @@
 import type { Provider } from "@opencode-ai/sdk/v2";
 import { describe, expect, it } from "vitest";
-import { resolveDefaultModel } from "../src/model";
+import { resolveDefaultModel, resolveModelContextWindow } from "../src/model";
 import type { SessionEntry } from "../src/types";
 
 function providerWithVariants(): Provider[] {
@@ -8,14 +8,18 @@ function providerWithVariants(): Provider[] {
     {
       id: "anthropic",
       name: "Anthropic",
-      models: {
-        "claude-sonnet-4.6": {
-          id: "claude-sonnet-4.6",
-          providerID: "anthropic",
-          name: "Claude Sonnet 4.6",
-          variants: {
-            fast: {},
-            thinking: {},
+        models: {
+          "claude-sonnet-4.6": {
+            id: "claude-sonnet-4.6",
+            providerID: "anthropic",
+            name: "Claude Sonnet 4.6",
+            limit: {
+              context: 200_000,
+              output: 8_000,
+            },
+            variants: {
+              fast: {},
+              thinking: {},
           },
         },
       },
@@ -76,5 +80,28 @@ describe("default model resolution", () => {
     expect(resolved.notice).toContain(
       "Configured mini model anthropic/claude-sonnet-4.6 (missing) was not found.",
     );
+  });
+
+  it("resolves a selected model context window from provider metadata", () => {
+    expect(
+      resolveModelContextWindow(providerWithVariants(), {
+        model: {
+          providerID: "anthropic",
+          modelID: "claude-sonnet-4.6",
+        },
+        variant: "fast",
+      }),
+    ).toBe(200_000);
+  });
+
+  it("returns undefined when the selected model is missing", () => {
+    expect(
+      resolveModelContextWindow(providerWithVariants(), {
+        model: {
+          providerID: "openai",
+          modelID: "gpt-5",
+        },
+      }),
+    ).toBeUndefined();
   });
 });

--- a/tests/session.test.ts
+++ b/tests/session.test.ts
@@ -1,10 +1,16 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 
-const { buildCopiedContext, getSessionEntries, resolveRuntimeMiniAgent } = vi.hoisted(() => ({
-  buildCopiedContext: vi.fn(() => ({ text: "main context", usedTokens: 31_000 })),
-  getSessionEntries: vi.fn(() => []),
-  resolveRuntimeMiniAgent: vi.fn(),
-}));
+const { buildCopiedContext, getSessionEntries, resolveRuntimeMiniAgent } = vi.hoisted(
+  () => ({
+    buildCopiedContext: vi.fn(() => ({
+      text: "main context",
+      usedTokens: 31_000,
+      totalAvailableTokens: 31_000,
+    })),
+    getSessionEntries: vi.fn(() => []),
+    resolveRuntimeMiniAgent: vi.fn(),
+  }),
+);
 
 vi.mock("../src/agent", async () => {
   const actual = await vi.importActual<typeof import("../src/agent")>(
@@ -439,9 +445,10 @@ describe("startQuestion", () => {
     expect(overlay?.state.footerCounter).toEqual({
       copiedContext: {
         usedTokens: 31_000,
+        totalAvailableTokens: 31_000,
         tokenLimit: 50_000,
-        text: "31.0K / 50.0K",
-        capReached: false,
+        text: "main 31.0K",
+        truncated: false,
       },
       miniSession: undefined,
       placeholder: undefined,
@@ -721,6 +728,147 @@ describe("startQuestion", () => {
     expect(overlay?.state.lastCompletedMiniInputTokens).toBe(5_334);
     expect(overlay?.state.footerCounter.miniSession?.text).toBe("5.3K (3%)");
   });
+
+  it.each(["main", "fresh"] as const)(
+    "increments the second completed response once in %s mode when updated before idle",
+    async (mode) => {
+      resolveRuntimeMiniAgent.mockResolvedValue(resolvedAgent());
+
+      const handlers: Record<string, (event: any) => void> = {};
+      const api = fakeApi();
+      (getSessionEntries as any).mockReturnValue([
+        assistantEntry({
+          id: "assistant-1",
+          text: "answer",
+          inputTokens: 5_240,
+          completed: true,
+        }),
+      ]);
+      api.event.on.mockImplementation((name: string, handler: (event: any) => void) => {
+        handlers[name] = handler;
+        return () => {};
+      });
+      let overlay: OverlayState | undefined;
+      const modelPreference: any = {
+        get: () => ({
+          model: {
+            providerID: "anthropic",
+            modelID: "claude-sonnet-4.6",
+          },
+          variant: "fast",
+        }),
+        set: vi.fn(),
+      };
+
+      await startQuestion(
+        api,
+        config(),
+        mode,
+        "session-1",
+        ((next: OverlayState | undefined) => {
+          overlay = next;
+        }) as any,
+        { get: () => undefined, set: vi.fn() },
+        modelPreference,
+        { get: () => false, set: vi.fn() },
+        vi.fn(),
+      );
+
+      handlers["session.idle"]({ properties: { sessionID: "mini-session" } });
+      expect(overlay?.state.lastCompletedMiniInputTokens).toBe(5_240);
+
+      (getSessionEntries as any).mockReturnValue([
+        assistantEntry({
+          id: "assistant-1",
+          text: "answer",
+          inputTokens: 5_240,
+          completed: true,
+        }),
+        assistantEntry({
+          id: "assistant-2",
+          text: "follow up",
+          inputTokens: 94,
+          completed: true,
+        }),
+      ]);
+
+      handlers["message.updated"]({ properties: { sessionID: "mini-session" } });
+      handlers["session.idle"]({ properties: { sessionID: "mini-session" } });
+
+      expect(overlay?.state.lastCompletedMiniInputTokens).toBe(5_334);
+      expect(overlay?.state.footerCounter.miniSession?.text).toBe("5.3K (3%)");
+    },
+  );
+
+  it.each(["main", "fresh"] as const)(
+    "increments the second completed response once in %s mode when its total equals the previous counter",
+    async (mode) => {
+      resolveRuntimeMiniAgent.mockResolvedValue(resolvedAgent());
+
+      const handlers: Record<string, (event: any) => void> = {};
+      const api = fakeApi();
+      (getSessionEntries as any).mockReturnValue([
+        assistantEntry({
+          id: "assistant-1",
+          text: "answer",
+          inputTokens: 5_240,
+          completed: true,
+        }),
+      ]);
+      api.event.on.mockImplementation((name: string, handler: (event: any) => void) => {
+        handlers[name] = handler;
+        return () => {};
+      });
+      let overlay: OverlayState | undefined;
+      const modelPreference: any = {
+        get: () => ({
+          model: {
+            providerID: "anthropic",
+            modelID: "claude-sonnet-4.6",
+          },
+          variant: "fast",
+        }),
+        set: vi.fn(),
+      };
+
+      await startQuestion(
+        api,
+        config(),
+        mode,
+        "session-1",
+        ((next: OverlayState | undefined) => {
+          overlay = next;
+        }) as any,
+        { get: () => undefined, set: vi.fn() },
+        modelPreference,
+        { get: () => false, set: vi.fn() },
+        vi.fn(),
+      );
+
+      handlers["session.idle"]({ properties: { sessionID: "mini-session" } });
+      (getSessionEntries as any).mockReturnValue([
+        assistantEntry({
+          id: "assistant-1",
+          text: "answer",
+          inputTokens: 5_240,
+          completed: true,
+        }),
+        assistantEntry({
+          id: "assistant-2",
+          text: "follow up",
+          inputTokens: 94,
+          cacheReadTokens: 5_146,
+          completed: true,
+        }),
+      ]);
+
+      handlers["message.updated"]({ properties: { sessionID: "mini-session" } });
+      handlers["session.idle"]({ properties: { sessionID: "mini-session" } });
+
+      expect(overlay?.state.lastCompletedMiniInputTokens).toBe(5_334);
+      expect(overlay?.state.footerCounter.miniSession?.text).toBe("5.3K (3%)");
+    },
+  );
 
   it("updates completed input tokens when cache metadata arrives after idle", async () => {
     resolveRuntimeMiniAgent.mockResolvedValue(resolvedAgent());

--- a/tests/session.test.ts
+++ b/tests/session.test.ts
@@ -468,7 +468,7 @@ describe("startQuestion", () => {
 
   it("stores exact completed input tokens after session idle", async () => {
     resolveRuntimeMiniAgent.mockResolvedValue(resolvedAgent());
-    getSessionEntries.mockReturnValue([
+    (getSessionEntries as any).mockReturnValue([
       assistantEntry({
         id: "assistant-1",
         text: "answer",
@@ -484,7 +484,7 @@ describe("startQuestion", () => {
       return () => {};
     });
     let overlay: OverlayState | undefined;
-    const modelPreference = {
+    const modelPreference: any = {
       get: () => ({
         model: {
           providerID: "anthropic",
@@ -521,7 +521,7 @@ describe("startQuestion", () => {
 
     const handlers: Record<string, (event: any) => void> = {};
     const api = fakeApi();
-    getSessionEntries.mockReturnValue([
+    (getSessionEntries as any).mockReturnValue([
       assistantEntry({
         id: "assistant-1",
         text: "answer",
@@ -534,7 +534,7 @@ describe("startQuestion", () => {
       return () => {};
     });
     let overlay: OverlayState | undefined;
-    const modelPreference = {
+    const modelPreference: any = {
       get: () => ({
         model: {
           providerID: "anthropic",
@@ -560,7 +560,7 @@ describe("startQuestion", () => {
     );
 
     handlers["session.idle"]({ properties: { sessionID: "mini-session" } });
-    getSessionEntries.mockReturnValue([
+    (getSessionEntries as any).mockReturnValue([
       assistantEntry({
         id: "assistant-1",
         text: "answer",
@@ -584,7 +584,7 @@ describe("startQuestion", () => {
 
     const api = fakeApi();
     let overlay: OverlayState | undefined;
-    const modelPreference = {
+    const modelPreference: any = {
       get: vi.fn(() => undefined),
       set: vi.fn(),
     };
@@ -625,7 +625,7 @@ describe("startQuestion", () => {
 
     const api = fakeApi();
     let overlay: OverlayState | undefined;
-    const modelPreference = {
+    const modelPreference: any = {
       get: vi.fn(() => undefined),
       set: vi.fn(),
     };
@@ -669,7 +669,7 @@ describe("startQuestion", () => {
 
     const api = fakeApi();
     let overlay: OverlayState | undefined;
-    const modelPreference = {
+    const modelPreference: any = {
       get: vi.fn(() => undefined),
       set: vi.fn(),
     };

--- a/tests/session.test.ts
+++ b/tests/session.test.ts
@@ -1,7 +1,8 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 
-const { formatFullContext, resolveRuntimeMiniAgent } = vi.hoisted(() => ({
-  formatFullContext: vi.fn(() => "main context"),
+const { buildCopiedContext, getSessionEntries, resolveRuntimeMiniAgent } = vi.hoisted(() => ({
+  buildCopiedContext: vi.fn(() => ({ text: "main context", usedTokens: 31_000 })),
+  getSessionEntries: vi.fn(() => []),
   resolveRuntimeMiniAgent: vi.fn(),
 }));
 
@@ -16,8 +17,8 @@ vi.mock("../src/agent", async () => {
 });
 
 vi.mock("../src/context", () => ({
-  getSessionEntries: vi.fn(() => []),
-  formatFullContext,
+  getSessionEntries,
+  buildCopiedContext,
 }));
 
 import { openMiniSession, startQuestion } from "../src/session";
@@ -55,7 +56,21 @@ function config(): MiniConfig {
 function fakeApi() {
   return {
     state: {
-      provider: [],
+      provider: [
+        {
+          id: "anthropic",
+          name: "Anthropic",
+          models: {
+            "claude-sonnet-4.6": {
+              id: "claude-sonnet-4.6",
+              providerID: "anthropic",
+              name: "Claude Sonnet 4.6",
+              limit: { context: 200_000, output: 8_000 },
+              variants: { fast: {} },
+            },
+          },
+        },
+      ],
       path: { directory: "/tmp/project" },
     },
     renderer: {
@@ -79,6 +94,29 @@ function fakeApi() {
     route: {
       current: { name: "session", params: { sessionID: "session-1" } },
     },
+  } as any;
+}
+
+function assistantEntry(options: {
+  id: string;
+  text: string;
+  inputTokens?: number;
+  completed?: boolean;
+}) {
+  return {
+    info: {
+      id: options.id,
+      role: "assistant",
+      providerID: "anthropic",
+      modelID: "claude-sonnet-4.6",
+      variant: "fast",
+      time: options.completed ? { completed: Date.now() } : {},
+      tokens:
+        options.inputTokens !== undefined
+          ? { input: options.inputTokens }
+          : undefined,
+    },
+    parts: [{ type: "text", text: options.text }],
   } as any;
 }
 
@@ -133,7 +171,9 @@ async function flushStreamingRender() {
 
 afterEach(() => {
   vi.useRealTimers();
-  formatFullContext.mockClear();
+  buildCopiedContext.mockClear();
+  getSessionEntries.mockReset();
+  getSessionEntries.mockReturnValue([]);
   resolveRuntimeMiniAgent.mockReset();
 });
 
@@ -354,7 +394,7 @@ describe("startQuestion", () => {
     );
 
     await Promise.resolve();
-    expect(formatFullContext).not.toHaveBeenCalled();
+    expect(buildCopiedContext).not.toHaveBeenCalled();
 
     agentResolution.resolve({
       mode: "plugin-managed",
@@ -367,6 +407,303 @@ describe("startQuestion", () => {
     });
 
     await opening;
+  });
+
+  it("shows copied-context usage when main mini opens", async () => {
+    resolveRuntimeMiniAgent.mockResolvedValue(resolvedAgent());
+
+    let overlay: OverlayState | undefined;
+
+    await startQuestion(
+      fakeApi(),
+      config(),
+      "main",
+      "session-1",
+      ((next: OverlayState | undefined) => {
+        overlay = next;
+      }) as any,
+      { get: () => undefined, set: vi.fn() },
+      { get: () => undefined, set: vi.fn() },
+      { get: () => false, set: vi.fn() },
+      vi.fn(),
+    );
+
+    expect(overlay?.state.footerCounter).toEqual({
+      copiedContext: {
+        usedTokens: 31_000,
+        tokenLimit: 50_000,
+        text: "31.0K / 50.0K",
+        capReached: false,
+      },
+      miniSession: undefined,
+      placeholder: undefined,
+    });
+  });
+
+  it("shows no counter when fresh mini opens", async () => {
+    resolveRuntimeMiniAgent.mockResolvedValue(resolvedAgent());
+
+    let overlay: OverlayState | undefined;
+
+    await startQuestion(
+      fakeApi(),
+      config(),
+      "fresh",
+      "session-1",
+      ((next: OverlayState | undefined) => {
+        overlay = next;
+      }) as any,
+      { get: () => undefined, set: vi.fn() },
+      { get: () => undefined, set: vi.fn() },
+      { get: () => false, set: vi.fn() },
+      vi.fn(),
+    );
+
+    expect(overlay?.state.footerCounter).toEqual({
+      copiedContext: undefined,
+      miniSession: undefined,
+      placeholder: undefined,
+    });
+  });
+
+  it("stores exact completed input tokens after session idle", async () => {
+    resolveRuntimeMiniAgent.mockResolvedValue(resolvedAgent());
+    getSessionEntries.mockReturnValue([
+      assistantEntry({
+        id: "assistant-1",
+        text: "answer",
+        inputTokens: 11_240,
+        completed: true,
+      }),
+    ]);
+
+    const handlers: Record<string, (event: any) => void> = {};
+    const api = fakeApi();
+    api.event.on.mockImplementation((name: string, handler: (event: any) => void) => {
+      handlers[name] = handler;
+      return () => {};
+    });
+    let overlay: OverlayState | undefined;
+    const modelPreference = {
+      get: () => ({
+        model: {
+          providerID: "anthropic",
+          modelID: "claude-sonnet-4.6",
+        },
+        variant: "fast",
+      }),
+      set: vi.fn(),
+    };
+
+    await startQuestion(
+      api,
+      config(),
+      "main",
+      "session-1",
+      ((next: OverlayState | undefined) => {
+        overlay = next;
+      }) as any,
+      { get: () => undefined, set: vi.fn() },
+      modelPreference,
+      { get: () => false, set: vi.fn() },
+      vi.fn(),
+    );
+
+    handlers["session.idle"]({ properties: { sessionID: "mini-session" } });
+
+    expect(overlay?.state.lastCompletedMiniInputTokens).toBe(11_240);
+    expect(overlay?.state.footerCounter.miniSession?.text).toBe("11.2K (6%)");
+  });
+
+  it("keeps the last completed exact value while a later response streams", async () => {
+    vi.useFakeTimers();
+    resolveRuntimeMiniAgent.mockResolvedValue(resolvedAgent());
+
+    const handlers: Record<string, (event: any) => void> = {};
+    const api = fakeApi();
+    getSessionEntries.mockReturnValue([
+      assistantEntry({
+        id: "assistant-1",
+        text: "answer",
+        inputTokens: 11_240,
+        completed: true,
+      }),
+    ]);
+    api.event.on.mockImplementation((name: string, handler: (event: any) => void) => {
+      handlers[name] = handler;
+      return () => {};
+    });
+    let overlay: OverlayState | undefined;
+    const modelPreference = {
+      get: () => ({
+        model: {
+          providerID: "anthropic",
+          modelID: "claude-sonnet-4.6",
+        },
+        variant: "fast",
+      }),
+      set: vi.fn(),
+    };
+
+    await startQuestion(
+      api,
+      config(),
+      "main",
+      "session-1",
+      ((next: OverlayState | undefined) => {
+        overlay = next;
+      }) as any,
+      { get: () => undefined, set: vi.fn() },
+      modelPreference,
+      { get: () => false, set: vi.fn() },
+      vi.fn(),
+    );
+
+    handlers["session.idle"]({ properties: { sessionID: "mini-session" } });
+    getSessionEntries.mockReturnValue([
+      assistantEntry({
+        id: "assistant-1",
+        text: "answer",
+        inputTokens: 11_240,
+        completed: true,
+      }),
+      assistantEntry({ id: "assistant-2", text: "streaming" }),
+    ]);
+
+    handlers["session.next.text.delta"]({
+      properties: { sessionID: "mini-session", delta: "more" },
+    });
+    await flushStreamingRender();
+
+    expect(overlay?.state.lastCompletedMiniInputTokens).toBe(11_240);
+    expect(overlay?.state.footerCounter.miniSession?.text).toBe("11.2K (6%)");
+  });
+
+  it("recalculates percentages immediately after a model change", async () => {
+    resolveRuntimeMiniAgent.mockResolvedValue(resolvedAgent());
+
+    const api = fakeApi();
+    let overlay: OverlayState | undefined;
+    const modelPreference = {
+      get: vi.fn(() => undefined),
+      set: vi.fn(),
+    };
+
+    await startQuestion(
+      api,
+      config(),
+      "main",
+      "session-1",
+      ((next: OverlayState | undefined) => {
+        overlay = next;
+      }) as any,
+      { get: () => undefined, set: vi.fn() },
+      modelPreference,
+      { get: () => false, set: vi.fn() },
+      (onAfterSelect) => {
+        if (!overlay) return;
+        overlay.state.lastCompletedMiniInputTokens = 100_000;
+        modelPreference.get.mockReturnValue({
+          model: {
+            providerID: "anthropic",
+            modelID: "claude-sonnet-4.6",
+          },
+          variant: "fast",
+        });
+        onAfterSelect();
+      },
+    );
+
+    overlay?.onChangeModel();
+
+    expect(overlay?.state.modelContextWindow).toBe(200_000);
+    expect(overlay?.state.footerCounter.miniSession?.text).toBe("100.0K (50%)");
+  });
+
+  it("changes the placeholder only after the exact mini-session value crosses the limit threshold", async () => {
+    resolveRuntimeMiniAgent.mockResolvedValue(resolvedAgent());
+
+    const api = fakeApi();
+    let overlay: OverlayState | undefined;
+    const modelPreference = {
+      get: vi.fn(() => undefined),
+      set: vi.fn(),
+    };
+
+    await startQuestion(
+      api,
+      config(),
+      "main",
+      "session-1",
+      ((next: OverlayState | undefined) => {
+        overlay = next;
+      }) as any,
+      { get: () => undefined, set: vi.fn() },
+      modelPreference,
+      { get: () => false, set: vi.fn() },
+      (onAfterSelect) => {
+        if (!overlay) return;
+        overlay.state.lastCompletedMiniInputTokens = 196_000;
+        modelPreference.get.mockReturnValue({
+          model: {
+            providerID: "anthropic",
+            modelID: "claude-sonnet-4.6",
+          },
+          variant: "fast",
+        });
+        onAfterSelect();
+      },
+    );
+
+    expect(overlay?.state.inputPlaceholder).toBeUndefined();
+
+    overlay?.onChangeModel();
+
+    expect(overlay?.state.inputPlaceholder).toBe(
+      "Session context limit reached...",
+    );
+  });
+
+  it("hides percentages and threshold effects when the model context window is unknown", async () => {
+    resolveRuntimeMiniAgent.mockResolvedValue(resolvedAgent());
+
+    const api = fakeApi();
+    let overlay: OverlayState | undefined;
+    const modelPreference = {
+      get: vi.fn(() => undefined),
+      set: vi.fn(),
+    };
+
+    await startQuestion(
+      api,
+      config(),
+      "main",
+      "session-1",
+      ((next: OverlayState | undefined) => {
+        overlay = next;
+      }) as any,
+      { get: () => undefined, set: vi.fn() },
+      modelPreference,
+      { get: () => false, set: vi.fn() },
+      (onAfterSelect) => {
+        if (!overlay) return;
+        overlay.state.lastCompletedMiniInputTokens = 196_000;
+        modelPreference.get.mockReturnValue({
+          model: {
+            providerID: "openai",
+            modelID: "gpt-5",
+          },
+        });
+        onAfterSelect();
+      },
+    );
+
+    overlay?.onChangeModel();
+
+    expect(overlay?.state.modelContextWindow).toBeUndefined();
+    expect(overlay?.state.footerCounter.miniSession?.text).toBe("196.0K");
+    expect(overlay?.state.footerCounter.miniSession?.warning).toBe(false);
+    expect(overlay?.state.inputPlaceholder).toBeUndefined();
   });
 
   it("uses the fresh keybind in the hide toast", async () => {

--- a/tests/session.test.ts
+++ b/tests/session.test.ts
@@ -101,6 +101,8 @@ function assistantEntry(options: {
   id: string;
   text: string;
   inputTokens?: number;
+  cacheReadTokens?: number;
+  cacheWriteTokens?: number;
   completed?: boolean;
 }) {
   return {
@@ -113,7 +115,13 @@ function assistantEntry(options: {
       time: options.completed ? { completed: Date.now() } : {},
       tokens:
         options.inputTokens !== undefined
-          ? { input: options.inputTokens }
+          ? {
+              input: options.inputTokens,
+              cache: {
+                read: options.cacheReadTokens ?? 0,
+                write: options.cacheWriteTokens ?? 0,
+              },
+            }
           : undefined,
     },
     parts: [{ type: "text", text: options.text }],
@@ -577,6 +585,225 @@ describe("startQuestion", () => {
 
     expect(overlay?.state.lastCompletedMiniInputTokens).toBe(11_240);
     expect(overlay?.state.footerCounter.miniSession?.text).toBe("11.2K (6%)");
+  });
+
+  it("includes cached input tokens after later completed responses", async () => {
+    resolveRuntimeMiniAgent.mockResolvedValue(resolvedAgent());
+
+    const handlers: Record<string, (event: any) => void> = {};
+    const api = fakeApi();
+    (getSessionEntries as any).mockReturnValue([
+      assistantEntry({
+        id: "assistant-1",
+        text: "answer",
+        inputTokens: 5_240,
+        completed: true,
+      }),
+    ]);
+    api.event.on.mockImplementation((name: string, handler: (event: any) => void) => {
+      handlers[name] = handler;
+      return () => {};
+    });
+    let overlay: OverlayState | undefined;
+    const modelPreference: any = {
+      get: () => ({
+        model: {
+          providerID: "anthropic",
+          modelID: "claude-sonnet-4.6",
+        },
+        variant: "fast",
+      }),
+      set: vi.fn(),
+    };
+
+    await startQuestion(
+      api,
+      config(),
+      "main",
+      "session-1",
+      ((next: OverlayState | undefined) => {
+        overlay = next;
+      }) as any,
+      { get: () => undefined, set: vi.fn() },
+      modelPreference,
+      { get: () => false, set: vi.fn() },
+      vi.fn(),
+    );
+
+    handlers["session.idle"]({ properties: { sessionID: "mini-session" } });
+
+    expect(overlay?.state.footerCounter.miniSession?.text).toBe("5.2K (3%)");
+
+    (getSessionEntries as any).mockReturnValue([
+      assistantEntry({
+        id: "assistant-1",
+        text: "answer",
+        inputTokens: 5_240,
+        completed: true,
+      }),
+      assistantEntry({
+        id: "assistant-2",
+        text: "follow up",
+        inputTokens: 94,
+        cacheReadTokens: 5_240,
+        completed: true,
+      }),
+    ]);
+
+    handlers["session.idle"]({ properties: { sessionID: "mini-session" } });
+
+    expect(overlay?.state.lastCompletedMiniInputTokens).toBe(5_334);
+    expect(overlay?.state.footerCounter.miniSession?.text).toBe("5.3K (3%)");
+  });
+
+  it("treats a lower later input value as a one-time incremental delta", async () => {
+    resolveRuntimeMiniAgent.mockResolvedValue(resolvedAgent());
+
+    const handlers: Record<string, (event: any) => void> = {};
+    const api = fakeApi();
+    (getSessionEntries as any).mockReturnValue([
+      assistantEntry({
+        id: "assistant-1",
+        text: "answer",
+        inputTokens: 5_240,
+        completed: true,
+      }),
+    ]);
+    api.event.on.mockImplementation((name: string, handler: (event: any) => void) => {
+      handlers[name] = handler;
+      return () => {};
+    });
+    let overlay: OverlayState | undefined;
+    const modelPreference: any = {
+      get: () => ({
+        model: {
+          providerID: "anthropic",
+          modelID: "claude-sonnet-4.6",
+        },
+        variant: "fast",
+      }),
+      set: vi.fn(),
+    };
+
+    await startQuestion(
+      api,
+      config(),
+      "main",
+      "session-1",
+      ((next: OverlayState | undefined) => {
+        overlay = next;
+      }) as any,
+      { get: () => undefined, set: vi.fn() },
+      modelPreference,
+      { get: () => false, set: vi.fn() },
+      vi.fn(),
+    );
+
+    handlers["session.idle"]({ properties: { sessionID: "mini-session" } });
+    (getSessionEntries as any).mockReturnValue([
+      assistantEntry({
+        id: "assistant-1",
+        text: "answer",
+        inputTokens: 5_240,
+        completed: true,
+      }),
+      assistantEntry({
+        id: "assistant-2",
+        text: "follow up",
+        inputTokens: 94,
+        completed: true,
+      }),
+    ]);
+
+    handlers["session.idle"]({ properties: { sessionID: "mini-session" } });
+    handlers["message.updated"]({ properties: { sessionID: "mini-session" } });
+
+    expect(overlay?.state.lastCompletedMiniInputTokens).toBe(5_334);
+    expect(overlay?.state.footerCounter.miniSession?.text).toBe("5.3K (3%)");
+  });
+
+  it("updates completed input tokens when cache metadata arrives after idle", async () => {
+    resolveRuntimeMiniAgent.mockResolvedValue(resolvedAgent());
+
+    const handlers: Record<string, (event: any) => void> = {};
+    const api = fakeApi();
+    (getSessionEntries as any).mockReturnValue([
+      assistantEntry({
+        id: "assistant-1",
+        text: "answer",
+        inputTokens: 5_240,
+        completed: true,
+      }),
+    ]);
+    api.event.on.mockImplementation((name: string, handler: (event: any) => void) => {
+      handlers[name] = handler;
+      return () => {};
+    });
+    let overlay: OverlayState | undefined;
+    const modelPreference: any = {
+      get: () => ({
+        model: {
+          providerID: "anthropic",
+          modelID: "claude-sonnet-4.6",
+        },
+        variant: "fast",
+      }),
+      set: vi.fn(),
+    };
+
+    await startQuestion(
+      api,
+      config(),
+      "main",
+      "session-1",
+      ((next: OverlayState | undefined) => {
+        overlay = next;
+      }) as any,
+      { get: () => undefined, set: vi.fn() },
+      modelPreference,
+      { get: () => false, set: vi.fn() },
+      vi.fn(),
+    );
+
+    handlers["session.idle"]({ properties: { sessionID: "mini-session" } });
+    (getSessionEntries as any).mockReturnValue([
+      assistantEntry({
+        id: "assistant-1",
+        text: "answer",
+        inputTokens: 5_240,
+        completed: true,
+      }),
+      assistantEntry({
+        id: "assistant-2",
+        text: "follow up",
+        inputTokens: 94,
+        completed: true,
+      }),
+    ]);
+
+    handlers["session.idle"]({ properties: { sessionID: "mini-session" } });
+    expect(overlay?.state.lastCompletedMiniInputTokens).toBe(5_334);
+
+    (getSessionEntries as any).mockReturnValue([
+      assistantEntry({
+        id: "assistant-1",
+        text: "answer",
+        inputTokens: 5_240,
+        completed: true,
+      }),
+      assistantEntry({
+        id: "assistant-2",
+        text: "follow up",
+        inputTokens: 94,
+        cacheReadTokens: 5_900,
+        completed: true,
+      }),
+    ]);
+
+    handlers["message.updated"]({ properties: { sessionID: "mini-session" } });
+
+    expect(overlay?.state.lastCompletedMiniInputTokens).toBe(5_994);
+    expect(overlay?.state.footerCounter.miniSession?.text).toBe("6.0K (3%)");
   });
 
   it("recalculates percentages immediately after a model change", async () => {


### PR DESCRIPTION
## Summary
- Adds mini-session and copied main-context counters to the footer.
- Redesigns the footer layout to better match the OpenCode session prompt style.
- Shows truncated copied context as `main copied/total` and keeps full copied context compact.
- Fixes repeated-response counter updates for both `/mini` and `/mini-fresh`.

## Why
The mini session footer needed clearer context visibility and a less crowded layout. The copied-context counter now makes it clear when only part of the main session was included, while the mini-session counter tracks completed response context more reliably.

## Testing
- `npm run typecheck`
- `npm test`