### PR TITLE
fix: compile TypeScript to JavaScript and verify packaged TUI entrypoint

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -28,6 +28,10 @@ jobs:
 
       - run: bun install --frozen-lockfile
 
+      - run: npm run test
+      - run: npm run typecheck
+      - run: npm run test:package
+
       - run: npm publish --provenance --access public
 
       - name: Create GitHub release

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,15 +8,18 @@
       "name": "opencode-mini-session",
       "version": "1.1.1",
       "dependencies": {
-        "@opencode-ai/plugin": "^1.17.18",
-        "@opencode-ai/sdk": "^1.17.18",
         "@opentui/core": "^0.4.3",
-        "@opentui/keymap": "^0.4.3",
         "@opentui/solid": "^0.4.3",
         "solid-js": "^1.9.12"
       },
       "devDependencies": {
+        "@babel/core": "^7.28.0",
+        "@babel/preset-typescript": "^7.27.1",
+        "@opencode-ai/plugin": "^1.17.18",
+        "@opencode-ai/sdk": "^1.17.18",
+        "@opentui/keymap": "^0.4.3",
         "@types/node": "^25.9.1",
+        "babel-preset-solid": "^1.9.12",
         "typescript": "^5.9.3",
         "vitest": "^4.1.7"
       },
@@ -28,6 +31,7 @@
       "version": "3.0.8",
       "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-3.0.8.tgz",
       "integrity": "sha512-oGMAgGoQdBXbZqNG0Ze56CHjDZ1IDYOwGYxYjO5KLSlz5HiNQ9udIXsPZ61VWaHGZ5XW/jyjmr6t2xz2jGVwbQ==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "json-schema": "^0.4.0"
@@ -530,6 +534,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -543,6 +548,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -556,6 +562,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -569,6 +576,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -582,6 +590,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -595,6 +604,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -624,6 +634,7 @@
       "version": "1.17.18",
       "resolved": "https://registry.npmjs.org/@opencode-ai/plugin/-/plugin-1.17.18.tgz",
       "integrity": "sha512-tqVBzhTHYUzO0laAmcQeBtT56tXYM5VGUk9V60O+cMx4kkSfac4qEfPVguCGUMJnfcU+u+EPvpME6xmHWoQE8w==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@ai-sdk/provider": "3.0.8",
@@ -652,6 +663,7 @@
       "version": "1.17.18",
       "resolved": "https://registry.npmjs.org/@opencode-ai/sdk/-/sdk-1.17.18.tgz",
       "integrity": "sha512-c/C9PhY8PrbcxDY+JIYtOZsrmMD0KzoVvxq+RGUrZ6LQp57SuVBbT4lfwA2G8Se5RNC1N5JtYjiuaXeECnF2SQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "cross-spawn": "7.0.6"
@@ -791,6 +803,7 @@
       "version": "0.4.3",
       "resolved": "https://registry.npmjs.org/@opentui/keymap/-/keymap-0.4.3.tgz",
       "integrity": "sha512-sinX0pyQBRrEvo89PSSUbSUDIYpL3xWo81VEfec58VFoVRB5FG48/deAtvRTQfJ8w1kgbzN8hzdOXdSm61zBmw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@opentui/core": "0.4.3"
@@ -1112,6 +1125,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
       "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@tybys/wasm-util": {
@@ -1463,6 +1477,7 @@
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
       "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "path-key": "^3.1.0",
@@ -1500,7 +1515,7 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
       "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "Apache-2.0",
       "engines": {
         "node": ">=8"
@@ -1519,6 +1534,7 @@
       "version": "4.0.0-beta.83",
       "resolved": "https://registry.npmjs.org/effect/-/effect-4.0.0-beta.83.tgz",
       "integrity": "sha512-0wsak8RtgGAr9UWSbVDgJHZcUqMSvicHcvaZv1MbMM7MCGgW4Rn/137J1MHQbwYPcwYGxT/IqehFd+UbYuj78w==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@standard-schema/spec": "^1.1.0",
@@ -1606,6 +1622,7 @@
       "version": "4.9.0",
       "resolved": "https://registry.npmjs.org/fast-check/-/fast-check-4.9.0.tgz",
       "integrity": "sha512-7ms6T7SybUev/PQITciI0yLM2pOSFy5zpG8Ty7tQofcVaQUvrMXp6CBwqF6fThLCLOrfBtuHAtwq6Yu4XPCllg==",
+      "dev": true,
       "funding": [
         {
           "type": "individual",
@@ -1655,6 +1672,7 @@
       "version": "0.1.6",
       "resolved": "https://registry.npmjs.org/find-my-way-ts/-/find-my-way-ts-0.1.6.tgz",
       "integrity": "sha512-a85L9ZoXtNAey3Y6Z+eBWW658kO/MwR7zIafkIUPUMf3isZG0NCs2pjW2wtjxAKuJPxMAsHUIP4ZPGv0o5gyTA==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/find-up": {
@@ -1761,6 +1779,7 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/ini/-/ini-7.0.0.tgz",
       "integrity": "sha512-ifK0CgjALofS5bkrcTy4RaQ9Vx2Knf/eLeIO+NaswQEpH1UblrtTSCIvN71qQDMq0PeQ/SSPojvEJp9vvvfr+w==",
+      "dev": true,
       "license": "ISC",
       "engines": {
         "node": "^22.22.2 || ^24.15.0 || >=26.0.0"
@@ -1785,6 +1804,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/js-tokens": {
@@ -1809,6 +1829,7 @@
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
       "integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==",
+      "dev": true,
       "license": "(AFL-2.1 OR BSD-3-Clause)"
     },
     "node_modules/json5": {
@@ -1827,6 +1848,7 @@
       "version": "1.30.0",
       "resolved": "https://registry.npmjs.org/kubernetes-types/-/kubernetes-types-1.30.0.tgz",
       "integrity": "sha512-Dew1okvhM/SQcIa2rcgujNndZwU8VnSapDgdxlYoB84ZlpAD43U6KLAFqYo17ykSFGHNPrg0qry0bP+GJd9v7Q==",
+      "dev": true,
       "license": "Apache-2.0"
     },
     "node_modules/lightningcss": {
@@ -2168,6 +2190,7 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/msgpackr/-/msgpackr-2.0.4.tgz",
       "integrity": "sha512-o1C5KRmuRt+apqMr1HuGSqWStZoRBUpEsCsl15uM9VdAF1qHLtvMOU2En747EnTyEl6c4pzPewRMFF31s1CNbA==",
+      "dev": true,
       "license": "MIT",
       "optionalDependencies": {
         "msgpackr-extract": "^3.0.4"
@@ -2177,6 +2200,7 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/msgpackr-extract/-/msgpackr-extract-3.0.4.tgz",
       "integrity": "sha512-4kmO/MdyUIkLIvTPr8VHLil4AtoKIoniWPIEk5+CDy0xnWC84azhSFmuJ7PxZdsYtiP5kEeQsORAVIeMgxT+Hw==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -2199,6 +2223,7 @@
       "version": "0.2.8",
       "resolved": "https://registry.npmjs.org/multipasta/-/multipasta-0.2.8.tgz",
       "integrity": "sha512-ZPWuMKyv0cSO29f7hozp+k6+crZbQijV8ipMvxNxRf2SwtYGTX1ZX89Kd20VV4H9Znonx+EQn+iy1wGQsJ+b+Q==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/nanoid": {
@@ -2224,6 +2249,7 @@
       "version": "5.2.2",
       "resolved": "https://registry.npmjs.org/node-gyp-build-optional-packages/-/node-gyp-build-optional-packages-5.2.2.tgz",
       "integrity": "sha512-s+w+rBWnpTMwSFbaE0UXsRlg7hU4FjekKU4eyAih5T8nJuNZT1nNsskXpxmeqSK9UzkBl6UgRlnKc8hz8IEqOw==",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -2328,6 +2354,7 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
       "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -2441,6 +2468,7 @@
       "version": "8.4.2",
       "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-8.4.2.tgz",
       "integrity": "sha512-vvuOGgcuPJAirlHvuQw1TrOiw7ptaIXXmIbNuiNOY6lNGJJH49PQ1Kj4nd783nPdQhQdicgOjVI2yI/9BD6/Ng==",
+      "dev": true,
       "funding": [
         {
           "type": "individual",
@@ -2554,6 +2582,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
       "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "shebang-regex": "^3.0.0"
@@ -2566,6 +2595,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -2705,6 +2735,7 @@
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/toml/-/toml-4.1.2.tgz",
       "integrity": "sha512-m0vXfHODcw3gk+KONAOlVQ5yNHc3yS3B1ybM3HS1vqDoS0RWTDDVBVVTYi8hH0k+2OM1vmo9fb1WX9EVqjqfHA==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=20"
@@ -2772,6 +2803,7 @@
       "version": "14.0.1",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.1.tgz",
       "integrity": "sha512-6ZxzVpzDXDa3bJWaHilVayA+BH/1zmxCJoVgvmqJnid/gPoKHxUrS/aC/T6LGQtNHT+XHG9fXPJB4d+IrU30Ew==",
+      "dev": true,
       "funding": [
         "https://github.com/sponsors/broofa",
         "https://github.com/sponsors/ctavan"
@@ -2968,6 +3000,7 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
       "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "isexe": "^2.0.0"
@@ -3006,6 +3039,7 @@
       "version": "2.9.0",
       "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
       "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
+      "dev": true,
       "license": "ISC",
       "bin": {
         "yaml": "bin.mjs"
@@ -3021,6 +3055,7 @@
       "version": "4.1.8",
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.1.8.tgz",
       "integrity": "sha512-5R1P+WwQqmmMIEACyzSvo4JXHY5WiAFHRMg+zBZKgKS+Q1viRa0C1hmUKtHltoIFKtIdki3pRxkmpP74jnNYHQ==",
+      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"

--- a/package.json
+++ b/package.json
@@ -6,30 +6,36 @@
     "opencode": ">=1.17.18 <2"
   },
   "exports": {
-    "./tui": "./src/index.ts"
+    "./tui": "./dist/index.js"
   },
   "files": [
-    "src"
+    "dist"
   ],
   "repository": {
     "type": "git",
     "url": "https://github.com/karamanliev/opencode-mini-session"
   },
   "scripts": {
+    "build": "node scripts/build.mjs",
+    "prepack": "npm run build",
     "release": "node scripts/release.mjs",
     "test": "vitest run",
+    "test:package": "node scripts/verify-packaged-tui.mjs",
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@opencode-ai/plugin": "^1.17.18",
-    "@opencode-ai/sdk": "^1.17.18",
     "@opentui/core": "^0.4.3",
-    "@opentui/keymap": "^0.4.3",
     "@opentui/solid": "^0.4.3",
     "solid-js": "^1.9.12"
   },
   "devDependencies": {
+    "@babel/core": "^7.28.0",
+    "@babel/preset-typescript": "^7.27.1",
+    "@opencode-ai/plugin": "^1.17.18",
+    "@opencode-ai/sdk": "^1.17.18",
+    "@opentui/keymap": "^0.4.3",
     "@types/node": "^25.9.1",
+    "babel-preset-solid": "^1.9.12",
     "typescript": "^5.9.3",
     "vitest": "^4.1.7"
   }

--- a/scripts/build.mjs
+++ b/scripts/build.mjs
@@ -1,0 +1,76 @@
+import { mkdir, readdir, readFile, rm, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import babel from "@babel/core";
+import typescriptPreset from "@babel/preset-typescript";
+import solidPreset from "babel-preset-solid";
+
+const rootDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const sourceDir = path.join(rootDir, "src");
+const distDir = path.join(rootDir, "dist");
+
+await rm(distDir, { recursive: true, force: true });
+await mkdir(distDir, { recursive: true });
+
+for (const sourcePath of await sourceFiles(sourceDir)) {
+  const relativePath = path.relative(sourceDir, sourcePath);
+  const outputPath = path.join(
+    distDir,
+    relativePath.replace(/\.[cm]?tsx?$/, ".js"),
+  );
+  const source = await readFile(sourcePath, "utf8");
+  const transformed = await babel.transformAsync(source, {
+    filename: sourcePath,
+    configFile: false,
+    babelrc: false,
+    plugins: [appendJsExtensions],
+    presets: [
+      [solidPreset, { moduleName: "@opentui/solid", generate: "universal" }],
+      [typescriptPreset],
+    ],
+  });
+
+  if (!transformed?.code) {
+    throw new Error(`Babel transform returned empty output for ${relativePath}`);
+  }
+
+  await mkdir(path.dirname(outputPath), { recursive: true });
+  await writeFile(outputPath, `${transformed.code}\n`);
+}
+
+function appendJsExtensions() {
+  return {
+    visitor: {
+      ImportDeclaration(importPath) {
+        appendExtension(importPath.node.source);
+      },
+      ExportNamedDeclaration(exportPath) {
+        if (exportPath.node.source) appendExtension(exportPath.node.source);
+      },
+      ExportAllDeclaration(exportPath) {
+        appendExtension(exportPath.node.source);
+      },
+    },
+  };
+}
+
+function appendExtension(source) {
+  if (source.value.startsWith(".") && !path.extname(source.value)) {
+    source.value = `${source.value}.js`;
+  }
+}
+
+async function sourceFiles(dir) {
+  const files = [];
+
+  for (const entry of await readdir(dir, { withFileTypes: true })) {
+    const entryPath = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      files.push(...await sourceFiles(entryPath));
+    } else if (entry.isFile() && /\.[cm]?tsx?$/.test(entry.name)) {
+      files.push(entryPath);
+    }
+  }
+
+  return files;
+}

--- a/scripts/release.mjs
+++ b/scripts/release.mjs
@@ -30,6 +30,7 @@ if (!branch || branch.startsWith("(")) {
 
 run("npm", ["run", "test"]);
 run("npm", ["run", "typecheck"]);
+run("npm", ["run", "test:package"]);
 
 run("npm", ["version", "--no-git-tag-version", versionArg]);
 

--- a/scripts/verify-packaged-tui.mjs
+++ b/scripts/verify-packaged-tui.mjs
@@ -1,0 +1,48 @@
+import { execFileSync } from "node:child_process";
+import { mkdtemp, mkdir, readFile, readdir, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+const tempDir = await mkdtemp(path.join(tmpdir(), "opencode-mini-session-"));
+const installDir = path.join(tempDir, "install");
+
+try {
+  const packed = JSON.parse(
+    execFileSync("npm", ["pack", "--json", "--pack-destination", tempDir], {
+      encoding: "utf8",
+    }),
+  );
+  const tarball = path.join(tempDir, packed[0].filename);
+
+  await mkdir(installDir);
+  execFileSync(
+    "npm",
+    ["install", "--ignore-scripts", "--no-package-lock", "--prefix", installDir, tarball],
+    { stdio: "inherit" },
+  );
+  const entryPath = path.join(
+    installDir,
+    "node_modules",
+    "opencode-mini-session",
+    "dist",
+    "index.js",
+  );
+  const distDir = path.dirname(entryPath);
+  for (const file of await readdir(distDir, { recursive: true })) {
+    if (!file.endsWith(".js")) continue;
+    const source = await readFile(path.join(distDir, file), "utf8");
+    if (/jsx(?:-dev)?-runtime/.test(source)) {
+      throw new Error(`Packaged TUI output imports a JSX runtime: ${file}`);
+    }
+  }
+  execFileSync(
+    "bun",
+    [
+      "--eval",
+      'import plugin from "opencode-mini-session/tui"; if (plugin.id !== "local.opencode-mini-session" || typeof plugin.tui !== "function") throw new Error("Invalid packaged TUI module");',
+    ],
+    { cwd: installDir, stdio: "inherit" },
+  );
+} finally {
+  await rm(tempDir, { recursive: true, force: true });
+}


### PR DESCRIPTION
## Summary

This PR compiles TypeScript to JavaScript during the build step and ensures the package exports the compiled JavaScript instead of raw TypeScript. The `package.json` has been updated accordingly, and dev-only dependencies moved to `devDependencies`. The CI pipeline now includes tests and package verification before publishing.

## Why

Previously the package exported TypeScript source, causing issues when installed from npm—especially with the TUI entrypoint (fixes #18, #20, #21, #22). This was rooted in an upstream packaging problem (opencode#33884). Compiling and verifying the output ensures correct behaviour for all users.

## Testing

- Manually verified the package output contains compiled JavaScript
- Updated CI workflow runs `npm test` and `npm run verify-packaged-tui` before publishing
- Tested the packaged artifact locally to confirm the TUI entrypoint works
- All existing unit tests continue to pass